### PR TITLE
improve readability of auto-generated mermaid markdown

### DIFF
--- a/dg.go
+++ b/dg.go
@@ -26,6 +26,13 @@ type directedGraph[NodeType any] struct {
 func (d *directedGraph[NodeType]) Mermaid() string {
     result := []string{}
     result = append(result, "flowchart TD")
+    result = append(result, "subgraph input")
+    for source := range d.connectionsFromNode {
+	if strings.HasPrefix(source, "input") {
+            result = append(result, source)
+	}
+    }
+    result = append(result, "end")
     for source, d := range d.connectionsFromNode {
         for destination := range d {
             result = append(result, fmt.Sprintf("%s-->%s", source, destination))


### PR DESCRIPTION
## Changes introduced with this PR

The auto-generated mermaid markdown for a workflow currently may render in a way that input parameters are in different "layers" of the graph visual. This could be very confusing to parse with a complex workflow.

_Note: Error nodes have been removed below for readability._

```mermaid
flowchart TD
input.elastic_username-->steps.elasticsearch
input.elastic_index-->steps.elasticsearch
input.sysbench_runtime-->steps.pcp
input.sysbench_runtime-->steps.sysbench
input.elastic_host-->steps.elasticsearch
input.elastic_password-->steps.elasticsearch
input.sysbench_cpumaxprime-->steps.sysbench
input.pmlogger_interval-->steps.pcp
input.sysbench_threads-->steps.sysbench
input.sysbench_events-->steps.sysbench
steps.metadata-->steps.metadata.outputs.success
steps.pcp.outputs.success-->steps.elasticsearch
steps.pcp.outputs.success-->output
steps.sysbench-->steps.sysbench.outputs.success
steps.sysbench.outputs.success-->steps.elasticsearch
steps.sysbench.outputs.success-->output
steps.pcp-->steps.pcp.outputs.success
steps.metadata.outputs.success-->steps.elasticsearch
steps.metadata.outputs.success-->output
steps.elasticsearch-->steps.elasticsearch.outputs.success
```

This change adds a `subgraph` that aligns all input parameters to the top level of the graph visual.

```mermaid
flowchart TD
subgraph input
input.elastic_username
input.elastic_index
input.sysbench_runtime
input.elastic_host
input.elastic_password
input.sysbench_cpumaxprime
input.pmlogger_interval
input.sysbench_threads
input.sysbench_events
end
input.elastic_username-->steps.elasticsearch
input.elastic_index-->steps.elasticsearch
input.sysbench_runtime-->steps.pcp
input.sysbench_runtime-->steps.sysbench
input.elastic_host-->steps.elasticsearch
input.elastic_password-->steps.elasticsearch
input.sysbench_cpumaxprime-->steps.sysbench
input.pmlogger_interval-->steps.pcp
input.sysbench_threads-->steps.sysbench
input.sysbench_events-->steps.sysbench
steps.metadata-->steps.metadata.outputs.success
steps.pcp.outputs.success-->steps.elasticsearch
steps.pcp.outputs.success-->output
steps.sysbench-->steps.sysbench.outputs.success
steps.sysbench.outputs.success-->steps.elasticsearch
steps.sysbench.outputs.success-->output
steps.pcp-->steps.pcp.outputs.success
steps.metadata.outputs.success-->steps.elasticsearch
steps.metadata.outputs.success-->output
steps.elasticsearch-->steps.elasticsearch.outputs.success
```

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).