### PR TITLE
correct misleading variable names and improve documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,25 +10,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Hard-coding version due to this bug: https://github.com/golangci/golangci-lint-action/issues/535
-          version: v1.47
+          version: v1.52.2
   test:
     name: go test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: Set up gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-      - uses: actions/cache@v2
+        uses: GoTestTools/gotestfmt-action@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod
@@ -50,7 +50,7 @@ jobs:
           go tool cover -func /tmp/coverage.out
           echo "::endgroup::"
       - name: Upload test log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: test-results
@@ -64,12 +64,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           go-version: 1.18
       - name: Set up gotestfmt
-        uses: GoTestTools/gotestfmt-action@v3
+        uses: GoTestTools/gotestfmt-action@v2
       - uses: actions/cache@v3
         with:
           path: |

--- a/interfaces.go
+++ b/interfaces.go
@@ -31,12 +31,12 @@ type Node[NodeType any] interface {
     // exist, ErrNodeNotFound is returned. If the connection had created a cycle, ErrConnectionWouldCreateACycle
     // is returned.
     Connect(toNodeID string) error
-    // DisconnectInbound removes a connection to the specified node. If the connection does not exist, an
+    // DisconnectInbound removes an incoming connection from the specified node. If the connection does not exist, an
     // ErrConnectionDoesNotExist is returned.
-    DisconnectInbound(toNodeID string) error
-    // DisconnectOutbound removes a connection to the specified node. If the connection does not exist, an
+    DisconnectInbound(fromNodeID string) error
+    // DisconnectOutbound removes an outgoing connection to the specified node. If the connection does not exist, an
     // ErrConnectionDoesNotExist is returned.
-    DisconnectOutbound(fromNodeID string) error
+    DisconnectOutbound(toNodeID string) error
     // Remove removes the current node and all connections from the DirectedGraph.
     Remove() error
     // ListInboundConnections lists all inbound connections to this node.


### PR DESCRIPTION
## Changes introduced with this PR
This PR corrects the wrong variable names used in the Node interface for the [disconnectinbound](https://github.com/arcalot/go-dgraph/blob/15d92ff5fdd7e92db9400557b80076ea72b5a9fa/dg.go#L206)() and [disconnectoutbound](https://github.com/arcalot/go-dgraph/blob/15d92ff5fdd7e92db9400557b80076ea72b5a9fa/dg.go#L230)() methods. 

The methods disconnectinbound and disconnectoutbound use different misleading variable names in the interface declaration as compared to the actual method. 


---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).