### PR TITLE
Upgrade Golang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,21 +14,20 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Hard-coding version due to this bug: https://github.com/golangci/golangci-lint-action/issues/535
-          version: v1.52.2
+          version: v1.55.2
   test:
     name: go test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: 1.21.6
       - name: Set up gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
@@ -64,12 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
-      - uses: actions/cache@v3
+          go-version: 1.21.6
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module go.arcalot.io/dgraph
 
-go 1.18
+go 1.21
 
 require go.arcalot.io/assert v1.3.0


### PR DESCRIPTION
## Changes introduced with this PR

- [X] Upgrade package to use golang 1.21.
- [X] Upgrade CI golang and actions.
- [X] Fix linting.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).