### PR TITLE
upgrade golang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,21 +14,20 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Hard-coding version due to this bug: https://github.com/golangci/golangci-lint-action/issues/535
-          version: v1.52.2
+          version: v1.55.2
   test:
     name: go test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: 1.21.6
       - name: Set up gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
@@ -64,12 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
-      - uses: actions/cache@v3
+          go-version: 1.21.6
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod

--- a/dg_test.go
+++ b/dg_test.go
@@ -17,8 +17,8 @@ func TestDirectedGraph_BasicNodeAdditionAndRemoval(t *testing.T) {
     n2, err := d.GetNodeByID("node-1")
     assert.NoError(t, err)
     assert.Equals(t, n, n2)
-
-    assert.ErrorR[dgraph.Node[string]](t)(d.GetNodeByID("node-2"))
+    
+    assert.ErrorR(t)(d.GetNodeByID("node-2"))
 
     nodes := d.ListNodesWithoutInboundConnections()
     assert.Equals(t, len(nodes), 1)
@@ -27,7 +27,7 @@ func TestDirectedGraph_BasicNodeAdditionAndRemoval(t *testing.T) {
 
     nodes = d.ListNodesWithoutInboundConnections()
     assert.Equals(t, len(nodes), 0)
-    assert.ErrorR[dgraph.Node[string]](t)(d.GetNodeByID("node-1"))
+    assert.ErrorR(t)(d.GetNodeByID("node-1"))
 }
 
 func TestDirectedGraph_ConnectSelf(t *testing.T) {

--- a/dg_test.go
+++ b/dg_test.go
@@ -17,7 +17,7 @@ func TestDirectedGraph_BasicNodeAdditionAndRemoval(t *testing.T) {
     n2, err := d.GetNodeByID("node-1")
     assert.NoError(t, err)
     assert.Equals(t, n, n2)
-    
+
     assert.ErrorR(t)(d.GetNodeByID("node-2"))
 
     nodes := d.ListNodesWithoutInboundConnections()

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module go.arcalot.io/dgraph
 
 go 1.21
 
-require go.arcalot.io/assert v1.3.0
+require go.arcalot.io/assert v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module go.arcalot.io/dgraph
 
-go 1.18
+go 1.21
 
 require go.arcalot.io/assert v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-go.arcalot.io/assert v1.3.0 h1:+uQex4s9gezATpTyFxUY5dlAcrwI1Me5fSmdcydGHho=
-go.arcalot.io/assert v1.3.0/go.mod h1:Xy3ScX0p9IMY89gdsgexOKxnmDr0nGHG9dV7p8Uxg7w=
+go.arcalot.io/assert v1.7.0 h1:PTLyeisNMUKpM9wXRDxResanBhuGOYO1xFK3v5b3FSw=
+go.arcalot.io/assert v1.7.0/go.mod h1:nNmWPoNUHFyrPkNrD2aASm5yPuAfiWdB/4X7Lw3ykHk=


### PR DESCRIPTION
## Changes introduced with this PR

- [X] Upgrade package to use golang 1.21.
- [X] Upgrade CI golang and actions.
- [X] Fix breaking change from `go-assert` upgrade.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).