### PR TITLE
restructure mermaid markdown output

### DIFF
--- a/dg.go
+++ b/dg.go
@@ -32,13 +32,12 @@ func (d *directedGraph[NodeType]) Mermaid() string {
     }
 
     errorPath := []string{"%% Error path"}
-    errorPathRegex := "error|crashed|failed|deploy_failed"
+    errorPathRegex, _ := regexp.Compile("error|crashed|failed|deploy_failed")
 
     for source, d := range d.connectionsFromNode {
         for destination := range d {
             destinationNodes := strings.Split(destination, ".")
-            match, _ := regexp.MatchString(
-                errorPathRegex,
+            match := errorPathRegex.MatchString(
                 destinationNodes[len(destinationNodes)-1],
             )
             if (match) {
@@ -49,9 +48,7 @@ func (d *directedGraph[NodeType]) Mermaid() string {
         }
     }
 
-    for _, connection := range errorPath {
-        result = append(result, connection)
-    }
+    result = append(result, errorPath...)
 
     result = append(result, "%% Mermaid end")
     return strings.Join(result, "\n") + "\n"

--- a/dg.go
+++ b/dg.go
@@ -24,6 +24,8 @@ type directedGraph[NodeType any] struct {
     connectionsToNode   map[string]map[string]struct{}
 }
 
+var errorPathRegex, _ = regexp.Compile("error|crashed|failed|deploy_failed")
+
 func (d *directedGraph[NodeType]) Mermaid() string {
     result := []string{
         "%% Mermaid markdown workflow",
@@ -32,15 +34,14 @@ func (d *directedGraph[NodeType]) Mermaid() string {
     }
 
     errorPath := []string{"%% Error path"}
-    errorPathRegex, _ := regexp.Compile("error|crashed|failed|deploy_failed")
 
     for source, d := range d.connectionsFromNode {
         for destination := range d {
             destinationNodes := strings.Split(destination, ".")
-            match := errorPathRegex.MatchString(
+            isErrorPath := errorPathRegex.MatchString(
                 destinationNodes[len(destinationNodes)-1],
             )
-            if (match) {
+            if (isErrorPath) {
                 errorPath = append(errorPath, fmt.Sprintf("%s-->%s", source, destination))
             } else {
                 result = append(result, fmt.Sprintf("%s-->%s", source, destination))

--- a/dg.go
+++ b/dg.go
@@ -24,7 +24,7 @@ type directedGraph[NodeType any] struct {
     connectionsToNode   map[string]map[string]struct{}
 }
 
-var errorPathRegex, _ = regexp.Compile("error|crashed|failed|deploy_failed")
+var errorPathRegex, _ = regexp.Compile("\\.(?:error|crashed|failed|deploy_failed)$")
 
 func (d *directedGraph[NodeType]) Mermaid() string {
     result := []string{
@@ -37,14 +37,12 @@ func (d *directedGraph[NodeType]) Mermaid() string {
 
     for source, d := range d.connectionsFromNode {
         for destination := range d {
-            destinationNodes := strings.Split(destination, ".")
-            isErrorPath := errorPathRegex.MatchString(
-                destinationNodes[len(destinationNodes)-1],
-            )
+            isErrorPath := errorPathRegex.MatchString(destination)
+            connection := fmt.Sprintf("%s-->%s", source, destination)
             if (isErrorPath) {
-                errorPath = append(errorPath, fmt.Sprintf("%s-->%s", source, destination))
+                errorPath = append(errorPath, connection)
             } else {
-                result = append(result, fmt.Sprintf("%s-->%s", source, destination))
+                result = append(result, connection)
             }
         }
     }

--- a/dg.go
+++ b/dg.go
@@ -24,7 +24,7 @@ type directedGraph[NodeType any] struct {
     connectionsToNode   map[string]map[string]struct{}
 }
 
-var errorPathRegex, _ = regexp.Compile("\\.(?:error|crashed|failed|deploy_failed)$")
+var errorPathRegex, _ = regexp.Compile(`\.(?:error|crashed|failed|deploy_failed)$`)
 
 func (d *directedGraph[NodeType]) Mermaid() string {
     result := []string{


### PR DESCRIPTION
## Changes introduced with this PR

Mostly address issue #4. Removes the input subgraph, which has been broken for a while since another change made the individual input nodes no longer visible to the function. Separates the success path from the error path, and adds some markdown comments to denote them, making it simple to copy-paste only the success path to the mermaid renderer for a simpler workflow chart. Changes the rendering from TopDown style to LeftRight style.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).