### PR TITLE
Dependency system

### DIFF
--- a/dg.go
+++ b/dg.go
@@ -184,8 +184,9 @@ func (d *directedGraph[NodeType]) ListNodesWithoutInboundConnections() map[strin
 	return result
 }
 
-// Validates the node IDs specified, and that it's a valid connection, then sets the `to` and `from` connections,
-// and adds the dependency to the node.
+// Validates the specified node IDs and confirms that a connection between them
+// would be valid, then sets the `to` and `from` connections and adds the
+// dependency to the `to` node.
 func (d *directedGraph[NodeType]) connectNodes(fromID, toID string, dependencyType DependencyType) error {
 	d.lock.Lock()
 	defer d.lock.Unlock()

--- a/dg.go
+++ b/dg.go
@@ -298,11 +298,12 @@ func (n *node[NodeType]) resolveNode(status ResolutionStatus) error {
 	if n.deleted {
 		return ErrNodeDeleted{n.id}
 	}
-	if n.status == "" {
-		return ErrNodeResolutionUnknown{n.id, n.status}
-	}
 	if n.status != Waiting {
-		return ErrNodeResolutionAlreadySet{n.id, n.status, status}
+		if status == Resolved || status == Unresolvable {
+			return ErrNodeResolutionAlreadySet{n.id, n.status, status}
+		} else {
+			return ErrNodeResolutionUnknown{n.id, n.status}
+		}
 	}
 	n.status = status
 	if status == Waiting {

--- a/dg.go
+++ b/dg.go
@@ -1,315 +1,435 @@
 package dgraph
 
 import (
-    "fmt"
-    "strings"
-    "sync"
-    "regexp"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
 )
 
 // New creates a new directed acyclic graph.
 func New[NodeType any]() DirectedGraph[NodeType] {
-    return &directedGraph[NodeType]{
-        &sync.Mutex{},
-        map[string]*node[NodeType]{},
-        map[string]map[string]struct{}{},
-        map[string]map[string]struct{}{},
-    }
+	return &directedGraph[NodeType]{
+		&sync.Mutex{},
+		map[string]*node[NodeType]{},
+		map[string]map[string]struct{}{},
+		map[string]map[string]struct{}{},
+	}
 }
 
 type directedGraph[NodeType any] struct {
-    lock                *sync.Mutex
-    nodes               map[string]*node[NodeType]
-    connectionsFromNode map[string]map[string]struct{}
-    connectionsToNode   map[string]map[string]struct{}
+	lock                *sync.Mutex
+	nodes               map[string]*node[NodeType]
+	connectionsFromNode map[string]map[string]struct{}
+	connectionsToNode   map[string]map[string]struct{}
 }
 
 var errorPathRegex, _ = regexp.Compile(`\.(?:error|crashed|failed|deploy_failed)$`)
 
 func (d *directedGraph[NodeType]) Mermaid() string {
-    result := []string{
-        "%% Mermaid markdown workflow",
-        "flowchart LR",
-        "%% Success path",
-    }
+	result := []string{
+		"%% Mermaid markdown workflow",
+		"flowchart LR",
+		"%% Success path",
+	}
 
-    errorPath := []string{"%% Error path"}
+	errorPath := []string{"%% Error path"}
 
-    for source, d := range d.connectionsFromNode {
-        for destination := range d {
-            isErrorPath := errorPathRegex.MatchString(destination)
-            connection := fmt.Sprintf("%s-->%s", source, destination)
-            if (isErrorPath) {
-                errorPath = append(errorPath, connection)
-            } else {
-                result = append(result, connection)
-            }
-        }
-    }
+	for source, d := range d.connectionsFromNode {
+		for destination := range d {
+			isErrorPath := errorPathRegex.MatchString(destination)
+			connection := fmt.Sprintf("%s-->%s", source, destination)
+			if isErrorPath {
+				errorPath = append(errorPath, connection)
+			} else {
+				result = append(result, connection)
+			}
+		}
+	}
 
-    result = append(result, errorPath...)
+	result = append(result, errorPath...)
 
-    result = append(result, "%% Mermaid end")
-    return strings.Join(result, "\n") + "\n"
+	result = append(result, "%% Mermaid end")
+	return strings.Join(result, "\n") + "\n"
 }
 
 func (d *directedGraph[NodeType]) Clone() DirectedGraph[NodeType] {
-    d.lock.Lock()
-    defer d.lock.Unlock()
+	d.lock.Lock()
+	defer d.lock.Unlock()
 
-    newDG := &directedGraph[NodeType]{
-        &sync.Mutex{},
-        make(map[string]*node[NodeType], len(d.nodes)),
-        d.cloneMap(d.connectionsFromNode),
-        d.cloneMap(d.connectionsToNode),
-    }
+	newDG := &directedGraph[NodeType]{
+		&sync.Mutex{},
+		make(map[string]*node[NodeType], len(d.nodes)),
+		d.cloneMap(d.connectionsFromNode),
+		d.cloneMap(d.connectionsToNode),
+	}
 
-    for nodeID, nodeData := range d.nodes {
-        newDG.nodes[nodeID] = &node[NodeType]{
-            deleted: nodeData.deleted,
-            id:      nodeID,
-            item:    nodeData.item,
-            dg:      newDG,
-        }
-    }
+	for nodeID, nodeData := range d.nodes {
+		newDG.nodes[nodeID] = &node[NodeType]{
+			deleted: nodeData.deleted,
+			id:      nodeID,
+			item:    nodeData.item,
+			dg:      newDG,
+		}
+	}
 
-    return newDG
+	return newDG
 }
 
 func (d *directedGraph[NodeType]) cloneMap(source map[string]map[string]struct{}) map[string]map[string]struct{} {
-    result := make(map[string]map[string]struct{}, len(source))
-    for nodeID1, tier2 := range source {
-        result[nodeID1] = make(map[string]struct{}, len(tier2))
-        for nodeID2 := range tier2 {
-            result[nodeID1][nodeID2] = struct{}{}
-        }
-    }
-    return result
+	result := make(map[string]map[string]struct{}, len(source))
+	for nodeID1, tier2 := range source {
+		result[nodeID1] = make(map[string]struct{}, len(tier2))
+		for nodeID2 := range tier2 {
+			result[nodeID1][nodeID2] = struct{}{}
+		}
+	}
+	return result
 }
 
 func (d *directedGraph[NodeType]) HasCycles() bool {
-    connectionsToNode := d.cloneMap(d.connectionsToNode)
-    for {
-        removeNodeIDs := []string{}
-        // Select all nodes that have no inbound connections
-        for nodeID, inboundConnections := range connectionsToNode {
-            if len(inboundConnections) == 0 {
-                removeNodeIDs = append(removeNodeIDs, nodeID)
-            }
-        }
-        // If no nodes without inbound connections are found...
-        if len(removeNodeIDs) == 0 {
-            // ...there is a cycle if there are nodes left
-            return len(connectionsToNode) != 0
-        }
-        for _, nodeID := range removeNodeIDs {
-            // Remove all previously-selected nodes
-            delete(connectionsToNode, nodeID)
-            // Remove connections from the selected nodes from the remaining nodes
-        }
-        for _, nodeID := range removeNodeIDs {
-            for targetNodeID := range connectionsToNode {
-                delete(connectionsToNode[targetNodeID], nodeID)
-            }
-        }
-    }
+	connectionsToNode := d.cloneMap(d.connectionsToNode)
+	for {
+		var removeNodeIDs []string
+		// Select all nodes that have no inbound connections
+		for nodeID, inboundConnections := range connectionsToNode {
+			if len(inboundConnections) == 0 {
+				removeNodeIDs = append(removeNodeIDs, nodeID)
+			}
+		}
+		// If no nodes without inbound connections are found...
+		if len(removeNodeIDs) == 0 {
+			// ...there is a cycle if there are nodes left
+			return len(connectionsToNode) != 0
+		}
+		for _, nodeID := range removeNodeIDs {
+			// Remove all previously-selected nodes
+			delete(connectionsToNode, nodeID)
+			// Remove connections from the selected nodes from the remaining nodes
+		}
+		for _, nodeID := range removeNodeIDs {
+			for targetNodeID := range connectionsToNode {
+				delete(connectionsToNode[targetNodeID], nodeID)
+			}
+		}
+	}
 }
 
 func (d *directedGraph[NodeType]) AddNode(id string, item NodeType) (Node[NodeType], error) {
-    d.lock.Lock()
-    defer d.lock.Unlock()
-    if _, ok := d.nodes[id]; ok {
-        return nil, ErrNodeAlreadyExists{
-            id,
-        }
-    }
-    d.nodes[id] = &node[NodeType]{
-        false,
-        id,
-        item,
-        d,
-    }
-    d.connectionsToNode[id] = map[string]struct{}{}
-    d.connectionsFromNode[id] = map[string]struct{}{}
-    return d.nodes[id], nil
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if _, ok := d.nodes[id]; ok {
+		return nil, ErrNodeAlreadyExists{
+			id,
+		}
+	}
+	d.nodes[id] = &node[NodeType]{
+		false,
+		id,
+		item,
+		false,
+		WaitingForDependencies,
+		make(map[string]DependencyType),
+		d,
+	}
+	d.connectionsToNode[id] = map[string]struct{}{}
+	d.connectionsFromNode[id] = map[string]struct{}{}
+	return d.nodes[id], nil
 }
 
 func (d *directedGraph[NodeType]) GetNodeByID(id string) (Node[NodeType], error) {
-    d.lock.Lock()
-    defer d.lock.Unlock()
+	d.lock.Lock()
+	defer d.lock.Unlock()
 
-    n, ok := d.nodes[id]
-    if !ok {
-        return nil, &ErrNodeNotFound{
-            id,
-        }
-    }
-    return n, nil
+	n, ok := d.nodes[id]
+	if !ok {
+		return nil, &ErrNodeNotFound{
+			id,
+		}
+	}
+	return n, nil
 }
 
 func (d *directedGraph[NodeType]) ListNodes() map[string]Node[NodeType] {
-    d.lock.Lock()
-    defer d.lock.Unlock()
+	d.lock.Lock()
+	defer d.lock.Unlock()
 
-    result := map[string]Node[NodeType]{}
-    for nodeID, n := range d.nodes {
-        result[nodeID] = n
-    }
-    return result
+	result := map[string]Node[NodeType]{}
+	for nodeID, n := range d.nodes {
+		result[nodeID] = n
+	}
+	return result
 }
 
 func (d *directedGraph[NodeType]) ListNodesWithoutInboundConnections() map[string]Node[NodeType] {
-    d.lock.Lock()
-    defer d.lock.Unlock()
+	d.lock.Lock()
+	defer d.lock.Unlock()
 
-    result := map[string]Node[NodeType]{}
-    for nodeID, n := range d.nodes {
-        if len(d.connectionsToNode[nodeID]) == 0 {
-            result[nodeID] = n
-        }
-    }
-    return result
+	result := map[string]Node[NodeType]{}
+	for nodeID, n := range d.nodes {
+		connections := d.connectionsToNode[nodeID]
+		if len(connections) == 0 {
+			result[nodeID] = n
+		}
+	}
+	return result
+}
+
+func (d *directedGraph[NodeType]) connectNodes(fromID, toID string, dependencyType DependencyType) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	// Make sure both nodes exist and are not deleted.
+	fromNode, ok := d.nodes[fromID]
+	if !ok {
+		return &ErrNodeNotFound{
+			fromID,
+		}
+	} else if fromNode.deleted {
+		return &ErrNodeDeleted{
+			fromID,
+		}
+	}
+	toNode, ok := d.nodes[toID]
+	if !ok {
+		return &ErrNodeNotFound{
+			toID,
+		}
+	} else if toNode.deleted {
+		return &ErrNodeDeleted{
+			toID,
+		}
+	}
+	// Validate that it's a valid, non-duplicate, connection.
+	if fromID == toID {
+		return &ErrCannotConnectToSelf{
+			fromID,
+		}
+	}
+	if _, ok := d.connectionsFromNode[fromID][toID]; ok {
+		return &ErrConnectionAlreadyExists{
+			fromID,
+			toID,
+		}
+	}
+	// Update the mappings.
+	d.connectionsFromNode[fromID][toID] = struct{}{}
+	d.connectionsToNode[toID][fromID] = struct{}{}
+	// Update the dependencies
+	toNode.outstandingDependencies[fromID] = dependencyType
+	return nil
 }
 
 type node[NodeType any] struct {
-    deleted bool
-    id      string
-    item    NodeType
-    dg      *directedGraph[NodeType]
+	deleted                 bool
+	id                      string
+	item                    NodeType
+	finalized               bool
+	status                  ResolutionStatus
+	outstandingDependencies map[string]DependencyType
+	dg                      *directedGraph[NodeType]
 }
 
-func (d *node[NodeType]) ID() string {
-    return d.id
+func (n *node[NodeType]) ID() string {
+	return n.id
 }
 
-func (d *node[NodeType]) Item() NodeType {
-    return d.item
+func (n *node[NodeType]) Item() NodeType {
+	return n.item
 }
 
-func (d *node[NodeType]) Connect(nodeID string) error {
-    d.dg.lock.Lock()
-    defer d.dg.lock.Unlock()
-    if d.deleted {
-        return &ErrNodeDeleted{
-            d.id,
-        }
-    }
-    if nodeID == d.id {
-        return &ErrCannotConnectToSelf{
-            nodeID,
-        }
-    }
-    if _, ok := d.dg.nodes[nodeID]; !ok {
-        return &ErrNodeNotFound{
-            nodeID,
-        }
-    }
-    if _, ok := d.dg.connectionsFromNode[d.id][nodeID]; ok {
-        return &ErrConnectionAlreadyExists{
-            d.id,
-            nodeID,
-        }
-    }
-    d.dg.connectionsFromNode[d.id][nodeID] = struct{}{}
-    d.dg.connectionsToNode[nodeID][d.id] = struct{}{}
-    return nil
+func (n *node[NodeType]) ResolveNode(status ResolutionStatus) error {
+	if n.status != WaitingForDependencies {
+		return ErrNodeResolutionAlreadySet{n.id, n.status, status}
+	}
+	n.status = status
+
+	return nil
 }
 
-func (d *node[NodeType]) DisconnectInbound(fromNodeID string) error {
-    d.dg.lock.Lock()
-    defer d.dg.lock.Unlock()
-    if d.deleted {
-        return &ErrNodeDeleted{
-            d.id,
-        }
-    }
-    if _, ok := d.dg.nodes[fromNodeID]; !ok {
-        return &ErrNodeNotFound{
-            fromNodeID,
-        }
-    }
-    if _, ok := d.dg.connectionsToNode[d.id][fromNodeID]; !ok {
-        return &ErrConnectionDoesNotExist{
-            d.id,
-            fromNodeID,
-        }
-    }
-    delete(d.dg.connectionsToNode[d.id], fromNodeID)
-    delete(d.dg.connectionsFromNode[fromNodeID], d.id)
-    return nil
+func (n *node[NodeType]) Connect(nodeID string) error {
+	return n.dg.connectNodes(n.id, nodeID, AndDependency)
+	/*n.dg.lock.Lock()
+	defer n.dg.lock.Unlock()
+	if n.deleted {
+		return &ErrNodeDeleted{
+			n.id,
+		}
+	}
+	if nodeID == n.id {
+		return &ErrCannotConnectToSelf{
+			nodeID,
+		}
+	}
+	if _, ok := n.dg.nodes[nodeID]; !ok {
+		return &ErrNodeNotFound{
+			nodeID,
+		}
+	}
+	if _, ok := n.dg.connectionsFromNode[n.id][nodeID]; ok {
+		return &ErrConnectionAlreadyExists{
+			n.id,
+			nodeID,
+		}
+	}
+	n.dg.connectionsFromNode[n.id][nodeID] = struct{}{}
+	n.dg.connectionsToNode[nodeID][n.id] = struct{}{}
+	return nil*/
 }
 
-func (d *node[NodeType]) DisconnectOutbound(toNodeID string) error {
-    d.dg.lock.Lock()
-    defer d.dg.lock.Unlock()
-    if d.deleted {
-        return &ErrNodeDeleted{
-            d.id,
-        }
-    }
-    if _, ok := d.dg.nodes[toNodeID]; !ok {
-        return &ErrNodeNotFound{
-            toNodeID,
-        }
-    }
-    if _, ok := d.dg.connectionsFromNode[d.id][toNodeID]; !ok {
-        return &ErrConnectionDoesNotExist{
-            d.id,
-            toNodeID,
-        }
-    }
-    delete(d.dg.connectionsFromNode[d.id], toNodeID)
-    delete(d.dg.connectionsToNode[toNodeID], d.id)
-    return nil
+func (n *node[NodeType]) ConnectDependency(fromNodeID string, dependencyType DependencyType) error {
+	return n.dg.connectNodes(fromNodeID, n.id, dependencyType)
 }
 
-func (d *node[NodeType]) Remove() error {
-    d.dg.lock.Lock()
-    defer d.dg.lock.Unlock()
-    if d.deleted {
-        return &ErrNodeDeleted{
-            d.id,
-        }
-    }
-    for toNodeID := range d.dg.connectionsFromNode[d.id] {
-        delete(d.dg.connectionsToNode[toNodeID], d.id)
-    }
-    delete(d.dg.connectionsFromNode, d.id)
-    for fromNodeID := range d.dg.connectionsToNode[d.id] {
-        delete(d.dg.connectionsFromNode[fromNodeID], d.id)
-    }
-    delete(d.dg.connectionsToNode, d.id)
-    delete(d.dg.nodes, d.id)
-    d.deleted = true
-    return nil
+func (n *node[NodeType]) DisconnectInbound(fromNodeID string) error {
+	n.dg.lock.Lock()
+	defer n.dg.lock.Unlock()
+	if n.deleted {
+		return &ErrNodeDeleted{
+			n.id,
+		}
+	}
+	if _, ok := n.dg.nodes[fromNodeID]; !ok {
+		return &ErrNodeNotFound{
+			fromNodeID,
+		}
+	}
+	if _, ok := n.dg.connectionsToNode[n.id][fromNodeID]; !ok {
+		return &ErrConnectionDoesNotExist{
+			n.id,
+			fromNodeID,
+		}
+	}
+	delete(n.dg.connectionsToNode[n.id], fromNodeID)
+	delete(n.dg.connectionsFromNode[fromNodeID], n.id)
+	return nil
 }
 
-func (d *node[NodeType]) ListInboundConnections() (map[string]Node[NodeType], error) {
-    d.dg.lock.Lock()
-    defer d.dg.lock.Unlock()
-    if d.deleted {
-        return nil, &ErrNodeDeleted{
-            d.id,
-        }
-    }
-    result := make(map[string]Node[NodeType], len(d.dg.connectionsToNode[d.id]))
-    for fromNodeID := range d.dg.connectionsToNode[d.id] {
-        result[fromNodeID] = d.dg.nodes[fromNodeID]
-    }
-    return result, nil
+func (n *node[NodeType]) DisconnectOutbound(toNodeID string) error {
+	n.dg.lock.Lock()
+	defer n.dg.lock.Unlock()
+	if n.deleted {
+		return &ErrNodeDeleted{
+			n.id,
+		}
+	}
+	if _, ok := n.dg.nodes[toNodeID]; !ok {
+		return &ErrNodeNotFound{
+			toNodeID,
+		}
+	}
+	if _, ok := n.dg.connectionsFromNode[n.id][toNodeID]; !ok {
+		return &ErrConnectionDoesNotExist{
+			n.id,
+			toNodeID,
+		}
+	}
+	delete(n.dg.connectionsFromNode[n.id], toNodeID)
+	delete(n.dg.connectionsToNode[toNodeID], n.id)
+	return nil
 }
 
-func (d *node[NodeType]) ListOutboundConnections() (map[string]Node[NodeType], error) {
-    d.dg.lock.Lock()
-    defer d.dg.lock.Unlock()
-    if d.deleted {
-        return nil, &ErrNodeDeleted{
-            d.id,
-        }
-    }
-    result := make(map[string]Node[NodeType], len(d.dg.connectionsFromNode[d.id]))
-    for toNodeID := range d.dg.connectionsFromNode[d.id] {
-        result[toNodeID] = d.dg.nodes[toNodeID]
-    }
-    return result, nil
+func (n *node[NodeType]) Remove() error {
+	n.dg.lock.Lock()
+	defer n.dg.lock.Unlock()
+	if n.deleted {
+		return &ErrNodeDeleted{
+			n.id,
+		}
+	}
+	for toNodeID := range n.dg.connectionsFromNode[n.id] {
+		delete(n.dg.connectionsToNode[toNodeID], n.id)
+	}
+	delete(n.dg.connectionsFromNode, n.id)
+	for fromNodeID := range n.dg.connectionsToNode[n.id] {
+		delete(n.dg.connectionsFromNode[fromNodeID], n.id)
+	}
+	delete(n.dg.connectionsToNode, n.id)
+	delete(n.dg.nodes, n.id)
+	n.deleted = true
+	return nil
+}
+
+func (n *node[NodeType]) ListInboundConnections() (map[string]Node[NodeType], error) {
+	n.dg.lock.Lock()
+	defer n.dg.lock.Unlock()
+	if n.deleted {
+		return nil, &ErrNodeDeleted{
+			n.id,
+		}
+	}
+	result := make(map[string]Node[NodeType], len(n.dg.connectionsToNode[n.id]))
+	for fromNodeID := range n.dg.connectionsToNode[n.id] {
+		result[fromNodeID] = n.dg.nodes[fromNodeID]
+	}
+	return result, nil
+}
+
+func (n *node[NodeType]) ListOutboundConnections() (map[string]Node[NodeType], error) {
+	n.dg.lock.Lock()
+	defer n.dg.lock.Unlock()
+	if n.deleted {
+		return nil, &ErrNodeDeleted{
+			n.id,
+		}
+	}
+	result := make(map[string]Node[NodeType], len(n.dg.connectionsFromNode[n.id]))
+	for toNodeID := range n.dg.connectionsFromNode[n.id] {
+		result[toNodeID] = n.dg.nodes[toNodeID]
+	}
+	return result, nil
+}
+
+func (n *node[NodeType]) DependencyResolved(dependencyNodeID string, dependencyResolution ResolutionStatus) error {
+	// TODO: Should we create a lock per node, and only sync the shared one when needed?
+	n.dg.lock.Lock()
+	defer n.dg.lock.Unlock()
+	// TODO: Should we fail, or just stop propagation if deleted?
+	if n.deleted {
+		return &ErrNodeDeleted{
+			n.id,
+		}
+	}
+	if dependencyResolution == WaitingForDependencies {
+		// Illegal state
+		return ErrNotifiedOfWaiting{n.id, dependencyNodeID}
+	}
+	dependencyType, isOutstandingDependency := n.outstandingDependencies[dependencyNodeID]
+	if !isOutstandingDependency {
+		// Now determine if the missing item was because the dependency was already resolved, or
+		// because there was never a connection.
+		_, isConnected := n.dg.connectionsToNode[n.id][dependencyNodeID]
+		if isConnected {
+			return ErrDuplicateDependencyResolution{n.id, dependencyNodeID}
+		} else {
+			return ErrConnectionDoesNotExist{dependencyNodeID, n.id}
+		}
+	}
+	delete(n.outstandingDependencies, dependencyNodeID)
+	if dependencyResolution == Unresolvable && dependencyType == AndDependency {
+		// Missing requirement. Fail.
+		// TODO
+	}
+	// Now determine if it's ready to be finalized (no more deferred dependencies).
+	/*hasAndDependency := false
+	for _, dependencyType := range n.outstandingDependencies {
+		if dependencyType == AndDependency {
+			hasAndDependency = true
+			break
+		}
+	}*/
+	// If resolution is unresolvable, fail if current type is AND, or if there are no remaining OR dependencies.
+	// Wait if there are remaining AND dependencies, completion dependencies, or if
+	// no OR dependencies are resolved.
+	// Success if there are no outstanding `AND` dependencies or `completion` dependencies, and
+	// the current type is OR and success.
+	// Otherwise, do nothing at this stage.
+}
+
+func (n *node[NodeType]) hasOutstandingAndDependency() bool {
+	for _, dependencyType := range n.outstandingDependencies {
+		if dependencyType == AndDependency {
+			return true
+		}
+	}
+	return false
 }

--- a/dg.go
+++ b/dg.go
@@ -411,7 +411,7 @@ func (n *node[NodeType]) ListOutboundConnections() (map[string]Node[NodeType], e
 	return result, nil
 }
 
-// dependencyResolved is used to notify a node that one of that node's dependencies have had their resolution
+// dependencyResolved is used to notify a node that one of that node's dependencies has had its resolution
 // status set. Once all dependencies are resolved, the node is set as finalized (ready for processing).
 // Caller should have appropriate mutex locked before calling.
 func (n *node[NodeType]) dependencyResolved(dependencyNodeID string, dependencyResolution ResolutionStatus) error {

--- a/dg.go
+++ b/dg.go
@@ -265,14 +265,22 @@ func (n *node[NodeType]) Item() NodeType {
 }
 
 func (n *node[NodeType]) ResolutionStatus() ResolutionStatus {
-	// The status can change and be accessed on different threads, so lock to prevent races.
+	// Since the status can be changed by another thread, we access it under a
+	// lock here to prevent Go from reporting a data race; however, the actual
+	// status may change as soon as the lock is released, and so the return
+	// value, unless it is a terminal value, does not necessarily represent the
+	// current value.
 	n.dg.lock.Lock()
 	defer n.dg.lock.Unlock()
 	return n.status
 }
 
 func (n *node[NodeType]) IsReady() bool {
-	// The status can change and be accessed on different threads, so lock to prevent races.
+	// Since the ready state can be changed by another thread, we access it under a
+	// lock here to prevent Go from reporting a data race; however, the actual
+	// ready state may change as soon as the lock is released, and so the return
+	// value, unless it is a terminal value, does not necessarily represent the
+	// current value.
 	n.dg.lock.Lock()
 	defer n.dg.lock.Unlock()
 	return n.ready

--- a/dg.go
+++ b/dg.go
@@ -222,24 +222,14 @@ func (d *directedGraph[NodeType]) PushStartingNodes() error {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
+nextNode:
 	for nodeID, n := range d.nodes {
-		// Search for nodes that have either no outstanding dependencies, or only
-		// obviated dependencies.
-		if len(n.outstandingDependencies) == 0 {
-			d.readyForProcessing[nodeID] = n
-		} else {
-			// Has nodes left. Check to see if they are all obviated.
-			hasNonObviatedDependencies := false
-			for _, dependency := range n.outstandingDependencies {
-				if dependency != ObviatedDependency {
-					hasNonObviatedDependencies = true
-					break
-				}
-			}
-			if !hasNonObviatedDependencies {
-				d.readyForProcessing[nodeID] = n
+		for _, dependency := range n.outstandingDependencies {
+			if dependency != ObviatedDependency {
+				continue nextNode
 			}
 		}
+		d.readyForProcessing[nodeID] = n
 	}
 	return nil
 }

--- a/dg.go
+++ b/dg.go
@@ -265,14 +265,14 @@ func (n *node[NodeType]) Item() NodeType {
 }
 
 func (n *node[NodeType]) ResolutionStatus() ResolutionStatus {
-	// The status can change, so lock to prevent data races.
+	// The status can change and be accessed on different threads, so lock to prevent races.
 	n.dg.lock.Lock()
 	defer n.dg.lock.Unlock()
 	return n.status
 }
 
 func (n *node[NodeType]) IsReady() bool {
-	// The ready state can change, so lock to prevent data races.
+	// The status can change and be accessed on different threads, so lock to prevent races.
 	n.dg.lock.Lock()
 	defer n.dg.lock.Unlock()
 	return n.ready

--- a/dg.go
+++ b/dg.go
@@ -428,7 +428,7 @@ func (n *node[NodeType]) dependencyResolved(dependencyNodeID string, dependencyR
 	}
 	// If resolution is unresolvable, fail if current type is AND, or if there are no remaining OR dependencies.
 	// Treat as resolved if is just a completion dependency.
-	if dependencyResolution == Unresolvable && dependencyType != CompletionDependency {
+	if dependencyResolution == Unresolvable && dependencyType != CompletionAndDependency {
 		// Check for the failure case.
 		if dependencyType == AndDependency || !n.hasOutstandingDependency(OrDependency) {
 			// Missing requirement. Mark as unresolvable, which propagates to outbound connections.
@@ -444,7 +444,7 @@ func (n *node[NodeType]) dependencyResolved(dependencyNodeID string, dependencyR
 		} else {
 			hasOrDependency = n.hasOutstandingDependency(OrDependency)
 		}
-		hasAndDependency := n.hasOutstandingDependency(AndDependency) || n.hasOutstandingDependency(CompletionDependency)
+		hasAndDependency := n.hasOutstandingDependency(AndDependency) || n.hasOutstandingDependency(CompletionAndDependency)
 		// Now determine if it's ready to be finalized (no more deferred dependencies).
 		if !(hasAndDependency || hasOrDependency) {
 			// Mark as ready for processing internally and in the DAG.

--- a/dg.go
+++ b/dg.go
@@ -312,10 +312,14 @@ func (n *node[NodeType]) resolveNode(status ResolutionStatus) error {
 	return nil
 }
 
+// Connect connects forward from the called node to the node with the ID specified
+// in fromNodeID. It has an AndDependency type for legacy reasons.
 func (n *node[NodeType]) Connect(nodeID string) error {
 	return n.dg.connectNodes(n.id, nodeID, AndDependency)
 }
 
+// ConnectDependency connects backward and sets a dependency. The connection is made
+// from the node with the ID specified to the called node.
 func (n *node[NodeType]) ConnectDependency(fromNodeID string, dependencyType DependencyType) error {
 	return n.dg.connectNodes(fromNodeID, n.id, dependencyType)
 }

--- a/dg_test.go
+++ b/dg_test.go
@@ -1,138 +1,374 @@
 package dgraph_test
 
 import (
-    "testing"
+	"testing"
 
-    "go.arcalot.io/assert"
-    "go.arcalot.io/dgraph"
+	"go.arcalot.io/assert"
+	"go.arcalot.io/dgraph"
 )
 
 func TestDirectedGraph_BasicNodeAdditionAndRemoval(t *testing.T) {
-    d := dgraph.New[string]()
-    n, err := d.AddNode("node-1", "Hello world!")
-    assert.NoError(t, err)
-    assert.Equals(t, n.ID(), "node-1")
-    assert.Equals(t, n.Item(), "Hello world!")
+	d := dgraph.New[string]()
+	n, err := d.AddNode("node-1", "Hello world!")
+	assert.NoError(t, err)
+	assert.Equals(t, n.ID(), "node-1")
+	assert.Equals(t, n.Item(), "Hello world!")
 
-    n2, err := d.GetNodeByID("node-1")
-    assert.NoError(t, err)
-    assert.Equals(t, n, n2)
+	n2, err := d.GetNodeByID("node-1")
+	assert.NoError(t, err)
+	assert.Equals(t, n, n2)
 
-    assert.ErrorR(t)(d.GetNodeByID("node-2"))
+	assert.ErrorR(t)(d.GetNodeByID("node-2"))
 
-    nodes := d.ListNodesWithoutInboundConnections()
-    assert.Equals(t, len(nodes), 1)
+	nodes := d.ListNodesWithoutInboundConnections()
+	assert.Equals(t, len(nodes), 1)
 
-    assert.NoError(t, n.Remove())
+	assert.NoError(t, n.Remove())
 
-    nodes = d.ListNodesWithoutInboundConnections()
-    assert.Equals(t, len(nodes), 0)
-    assert.ErrorR(t)(d.GetNodeByID("node-1"))
+	nodes = d.ListNodesWithoutInboundConnections()
+	assert.Equals(t, len(nodes), 0)
+	assert.ErrorR(t)(d.GetNodeByID("node-1"))
 }
 
 func TestDirectedGraph_ConnectSelf(t *testing.T) {
-    d := dgraph.New[string]()
-    n, err := d.AddNode("node-1", "Hello world!")
-    assert.NoError(t, err)
-    assert.Equals(t, n.ID(), "node-1")
-    assert.Equals(t, n.Item(), "Hello world!")
+	d := dgraph.New[string]()
+	n, err := d.AddNode("node-1", "Hello world!")
+	assert.NoError(t, err)
+	assert.Equals(t, n.ID(), "node-1")
+	assert.Equals(t, n.Item(), "Hello world!")
 
-    assert.Error(t, n.Connect("node-1"))
+	assert.Error(t, n.Connect("node-1"))
 }
 
 func TestDirectedGraph_Connect(t *testing.T) {
-    d := dgraph.New[string]()
-    n1, err := d.AddNode("node-1", "test1")
-    assert.NoError(t, err)
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
 
-    n2, err := d.AddNode("node-2", "test2")
-    assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
 
-    t.Run("connect", func(t *testing.T) {
-        assert.NoError(t, n1.Connect(n2.ID()))
-        assert.Error(t, n1.Connect(n2.ID()))
-        n1In, err := n1.ListInboundConnections()
-        assert.NoError(t, err)
-        assert.Equals(t, len(n1In), 0)
-        n1Out, err := n1.ListOutboundConnections()
-        assert.NoError(t, err)
-        assert.Equals(t, len(n1Out), 1)
-        assert.Equals(t, n1Out["node-2"].ID(), "node-2")
-        n2In, err := n2.ListInboundConnections()
-        assert.NoError(t, err)
-        assert.Equals(t, len(n2In), 1)
-        assert.Equals(t, n2In["node-1"].ID(), "node-1")
-        n2Out, err := n2.ListOutboundConnections()
-        assert.NoError(t, err)
-        assert.Equals(t, len(n2Out), 0)
-        starterNodes := d.ListNodesWithoutInboundConnections()
-        assert.Equals(t, len(starterNodes), 1)
-        assert.Equals(t, starterNodes["node-1"].ID(), "node-1")
-    })
-    t.Run("disconnect", func(t *testing.T) {
-        assert.NoError(t, n2.DisconnectInbound(n1.ID()))
-        n1In, err := n1.ListInboundConnections()
-        assert.NoError(t, err)
-        assert.Equals(t, len(n1In), 0)
-        n1Out, err := n1.ListOutboundConnections()
-        assert.NoError(t, err)
-        assert.Equals(t, len(n1Out), 0)
+	t.Run("connect", func(t *testing.T) {
+		assert.NoError(t, n1.Connect(n2.ID()))
+		assert.Error(t, n1.Connect(n2.ID()))
+		n1In, err := n1.ListInboundConnections()
+		assert.NoError(t, err)
+		assert.Equals(t, len(n1In), 0)
+		n1Out, err := n1.ListOutboundConnections()
+		assert.NoError(t, err)
+		assert.Equals(t, len(n1Out), 1)
+		assert.Equals(t, n1Out["node-2"].ID(), "node-2")
+		n2In, err := n2.ListInboundConnections()
+		assert.NoError(t, err)
+		assert.Equals(t, len(n2In), 1)
+		assert.Equals(t, n2In["node-1"].ID(), "node-1")
+		n2Out, err := n2.ListOutboundConnections()
+		assert.NoError(t, err)
+		assert.Equals(t, len(n2Out), 0)
+		starterNodes := d.ListNodesWithoutInboundConnections()
+		assert.Equals(t, len(starterNodes), 1)
+		assert.Equals(t, starterNodes["node-1"].ID(), "node-1")
+	})
+	t.Run("disconnect", func(t *testing.T) {
+		assert.NoError(t, n2.DisconnectInbound(n1.ID()))
+		n1In, err := n1.ListInboundConnections()
+		assert.NoError(t, err)
+		assert.Equals(t, len(n1In), 0)
+		n1Out, err := n1.ListOutboundConnections()
+		assert.NoError(t, err)
+		assert.Equals(t, len(n1Out), 0)
 
-        n2In, err := n2.ListInboundConnections()
-        assert.NoError(t, err)
-        assert.Equals(t, len(n2In), 0)
-        n2Out, err := n2.ListOutboundConnections()
-        assert.NoError(t, err)
-        assert.Equals(t, len(n2Out), 0)
+		n2In, err := n2.ListInboundConnections()
+		assert.NoError(t, err)
+		assert.Equals(t, len(n2In), 0)
+		n2Out, err := n2.ListOutboundConnections()
+		assert.NoError(t, err)
+		assert.Equals(t, len(n2Out), 0)
 
-        starterNodes := d.ListNodesWithoutInboundConnections()
-        assert.Equals(t, len(starterNodes), 2)
-        assert.Equals(t, starterNodes["node-1"].ID(), "node-1")
-        assert.Equals(t, starterNodes["node-2"].ID(), "node-2")
-    })
+		starterNodes := d.ListNodesWithoutInboundConnections()
+		assert.Equals(t, len(starterNodes), 2)
+		assert.Equals(t, starterNodes["node-1"].ID(), "node-1")
+		assert.Equals(t, starterNodes["node-2"].ID(), "node-2")
+	})
 }
 
 func TestDirectedGraph_Clone(t *testing.T) {
-    d := dgraph.New[string]()
-    _, err := d.AddNode("node-1", "test1")
-    assert.NoError(t, err)
+	d := dgraph.New[string]()
+	_, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
 
-    n2, err := d.AddNode("node-2", "test2")
-    assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
 
-    n3, err := d.AddNode("node-3", "test3")
-    assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
 
-    assert.NoError(t, n3.Connect(n2.ID()))
+	assert.NoError(t, n3.Connect(n2.ID()))
 
-    d2 := d.Clone()
+	d2 := d.Clone()
 
-    d2n2, err := d2.GetNodeByID("node-2")
-    assert.NoError(t, err)
-    assert.NoError(t, d2n2.Remove())
+	d2n2, err := d2.GetNodeByID("node-2")
+	assert.NoError(t, err)
+	assert.NoError(t, d2n2.Remove())
 
-    assert.Equals(t, len(d.ListNodesWithoutInboundConnections()), 2)
-    assert.Equals(t, len(d2.ListNodesWithoutInboundConnections()), 2)
-    n3Out, err := n3.ListOutboundConnections()
-    assert.NoError(t, err)
-    assert.Equals(t, len(n3Out), 1)
+	assert.Equals(t, len(d.ListNodesWithoutInboundConnections()), 2)
+	assert.Equals(t, len(d2.ListNodesWithoutInboundConnections()), 2)
+	n3Out, err := n3.ListOutboundConnections()
+	assert.NoError(t, err)
+	assert.Equals(t, len(n3Out), 1)
 }
 
 func TestDirectedGraph_HasCycles(t *testing.T) {
-    d := dgraph.New[string]()
-    n1, err := d.AddNode("node-1", "test1")
-    assert.NoError(t, err)
-    n2, err := d.AddNode("node-2", "test2")
-    assert.NoError(t, err)
-    n3, err := d.AddNode("node-3", "test3")
-    assert.NoError(t, err)
-    assert.NoError(t, n1.Connect(n2.ID()))
-    assert.NoError(t, n2.Connect(n3.ID()))
-    assert.Equals(t, d.HasCycles(), false)
-    assert.NoError(t, n3.Connect(n2.ID()))
-    assert.Equals(t, d.HasCycles(), true)
-    assert.NoError(t, n2.DisconnectOutbound(n3.ID()))
-    assert.Equals(t, d.HasCycles(), false)
-    assert.NoError(t, n2.Connect(n1.ID()))
-    assert.Equals(t, d.HasCycles(), true)
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+	assert.NoError(t, n1.Connect(n2.ID()))
+	assert.NoError(t, n2.Connect(n3.ID()))
+	assert.Equals(t, d.HasCycles(), false)
+	assert.NoError(t, n3.Connect(n2.ID()))
+	assert.Equals(t, d.HasCycles(), true)
+	assert.NoError(t, n2.DisconnectOutbound(n3.ID()))
+	assert.Equals(t, d.HasCycles(), false)
+	assert.NoError(t, n2.Connect(n1.ID()))
+	assert.Equals(t, d.HasCycles(), true)
 }
+
+func TestDirectedGraph_OneAndDependency1(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+
+	// Use simple connect method, which will set an AND dependency.
+	assert.NoError(t, n1.Connect(n2.ID()))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+	assert.NoError(t, n1.ResolveNode(dgraph.Resolved))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n2.ID())
+}
+
+func TestDirectedGraph_OneAndDependency2(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+
+	// Use the dependency connection method instead.
+	assert.NoError(t, n2.ConnectDependency(n1.ID(), dgraph.AndDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+	assert.NoError(t, n1.ResolveNode(dgraph.Resolved))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n2.ID())
+}
+
+// Test two AND dependencies.
+func TestDirectedGraph_TwoAndDependencies(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+
+	// Use the dependency connection method instead.
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.AndDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.AndDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 2)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+	// Resolve the first. This isn't enough to fulfill the dependencies.
+	assert.NoError(t, n2.ResolveNode(dgraph.Resolved))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 0)
+	// Resolve the second. This should now fulfill the dependencies.
+	assert.NoError(t, n3.ResolveNode(dgraph.Resolved))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+}
+
+// Test one OR dependency.
+func TestDirectedGraph_OneOrDependency(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+
+	// Use the dependency connection method instead.
+	assert.NoError(t, n2.ConnectDependency(n1.ID(), dgraph.OrDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+	assert.NoError(t, n1.ResolveNode(dgraph.Resolved))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n2.ID())
+}
+
+// Test two OR dependencies.
+func TestDirectedGraph_TwoOrDependencies1(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+
+	// Use the dependency connection method instead.
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.OrDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.OrDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 2)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+	// Resolve one node: n2
+	assert.NoError(t, n2.ResolveNode(dgraph.Resolved))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+}
+
+func TestDirectedGraph_TwoOrDependencies2(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+
+	// Use the dependency connection method instead.
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.OrDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.OrDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 2)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+	// Resolve one node: n2
+	assert.NoError(t, n2.ResolveNode(dgraph.Resolved))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+}
+
+// Test two ANDs and two OR dependencies, with the OR resolving before the AND.
+func TestDirectedGraph_TwoOrAndAndDependencies1(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+	n4, err := d.AddNode("node-4", "test4")
+	assert.NoError(t, err)
+	n5, err := d.AddNode("node-5", "test5")
+	assert.NoError(t, err)
+
+	// Use the dependency connection method instead.
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.OrDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.OrDependency))
+	assert.NoError(t, n1.ConnectDependency(n4.ID(), dgraph.AndDependency))
+	assert.NoError(t, n1.ConnectDependency(n5.ID(), dgraph.AndDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 4)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+	assert.SliceContains(t, n4, readyNodes)
+	assert.SliceContains(t, n5, readyNodes)
+	// Resolve one OR. That alone is not enough for n1 to be ready. No need to resolve n2, too.
+	assert.NoError(t, n2.ResolveNode(dgraph.Resolved))
+	assert.Equals(t, len(d.PopReadyNodes()), 0)
+	// Resolve both ANDs. It should resolve once both of them are resolved, but not just one.
+	assert.NoError(t, n4.ResolveNode(dgraph.Resolved))
+	assert.Equals(t, len(d.PopReadyNodes()), 0)
+	assert.NoError(t, n5.ResolveNode(dgraph.Resolved))
+
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+}
+
+// Test two ANDs and two OR dependencies, with the AND resolving before the OR.
+func TestDirectedGraph_TwoOrAndAndDependencies2(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+	n4, err := d.AddNode("node-4", "test4")
+	assert.NoError(t, err)
+	n5, err := d.AddNode("node-5", "test5")
+	assert.NoError(t, err)
+
+	// Use the dependency connection method instead.
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.OrDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.OrDependency))
+	assert.NoError(t, n1.ConnectDependency(n4.ID(), dgraph.AndDependency))
+	assert.NoError(t, n1.ConnectDependency(n5.ID(), dgraph.AndDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 4)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+	assert.SliceContains(t, n4, readyNodes)
+	assert.SliceContains(t, n5, readyNodes)
+
+	// Resolve both ANDs. It still needs the OR to resolve.
+	assert.NoError(t, n4.ResolveNode(dgraph.Resolved))
+	assert.Equals(t, len(d.PopReadyNodes()), 0)
+	assert.NoError(t, n5.ResolveNode(dgraph.Resolved))
+	assert.Equals(t, len(d.PopReadyNodes()), 0)
+
+	// Resolve one OR. That should now be enough to resolve it.
+	assert.NoError(t, n2.ResolveNode(dgraph.Resolved))
+
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+}
+
+// TODO: Test unresolvable with a simple AND
+// TODO: Test unresolvable with a simple OR.
+// TODO: Test unresolvable with two AND with one failure.
+// TODO: Test unresolvable with two OR with one failure and one success.
+// TODO: Test unresolvable with a simple completion dependency.
+// TODO: Test unresolvable with a completion dependency and an AND.
+// TODO: Test unresolvable with a completion dependency and two OR, with the completion dependency unresolvable.
+// TODO: Test unresolvable with two ORs and two AND.

--- a/dg_test.go
+++ b/dg_test.go
@@ -164,6 +164,7 @@ func testSingleResolutionDependency(
 	readyNodes = d.PopReadyNodes()
 	assert.Equals(t, len(readyNodes), 1)
 	assert.MapContainsKey(t, dependentNode.ID(), readyNodes)
+	assert.Equals(t, readyNodes[dependentNode.ID()], expectedDependentNodeResolution)
 }
 
 func TestDirectedGraph_OneAndDependencyConnect(t *testing.T) {
@@ -240,7 +241,6 @@ func TestDirectedGraph_ChainedAndDependencies(t *testing.T) {
 	readyNodes = d.PopReadyNodes()
 	assert.Equals(t, len(readyNodes), 1)
 	assert.MapContainsKey(t, dependentNode.ID(), readyNodes)
-
 }
 
 func TestDirectedGraph_OneOrDependency(t *testing.T) {
@@ -297,7 +297,6 @@ func TestDirectedGraph_TwoOrDependenciesResolveSecond(t *testing.T) {
 	readyNodes = d.PopReadyNodes()
 	assert.Equals(t, len(readyNodes), 1)
 	assert.MapContainsKey(t, dependentNode.ID(), readyNodes)
-
 }
 
 // Test two ANDs and two OR dependencies, with one OR resolving before the ANDs.
@@ -342,7 +341,6 @@ func TestDirectedGraph_TwoOrAndTwoAndDependencies(t *testing.T) {
 	readyNodes = d.PopReadyNodes()
 	assert.Equals(t, len(readyNodes), 1)
 	assert.MapContainsKey(t, dependentNode.ID(), readyNodes)
-
 }
 
 // Test one AND and two OR dependencies, with both ORs resolving before the AND.
@@ -379,7 +377,6 @@ func TestDirectedGraph_BothOrAndOneAndDependencies(t *testing.T) {
 	readyNodes = d.PopReadyNodes()
 	assert.Equals(t, len(readyNodes), 1)
 	assert.MapContainsKey(t, dependentNode.ID(), readyNodes)
-
 }
 
 // Test an AND and two OR dependencies, with the AND resolving before either OR.
@@ -416,7 +413,6 @@ func TestDirectedGraph_OneAndAndTwoOrDependencies(t *testing.T) {
 	readyNodes = d.PopReadyNodes()
 	assert.Equals(t, len(readyNodes), 1)
 	assert.MapContainsKey(t, dependentNode.ID(), readyNodes)
-
 }
 
 // Test `Unresolvable` with a simple AND
@@ -744,6 +740,5 @@ func TestDirectedGraph_PushStartingNodes(t *testing.T) {
 	readyNodes := d.PopReadyNodes()
 	assert.Equals(t, len(readyNodes), 2)
 	assert.MapContainsKey(t, noDependencies.ID(), readyNodes)
-	// Obviated dependencies should not count, so it should have been marked ready.
 	assert.MapContainsKey(t, onlyObviatedDependencies.ID(), readyNodes)
 }

--- a/dg_test.go
+++ b/dg_test.go
@@ -137,7 +137,14 @@ func TestDirectedGraph_HasCycles(t *testing.T) {
 	assert.Equals(t, d.HasCycles(), true)
 }
 
-func TestDirectedGraph_OneAndDependencyConnect(t *testing.T) {
+// For tests when you have two nodes (n1 and n2), and n2 becomes ready when n1 resolves.
+// Set the dependency connection with the closure.
+func testSingleResolutionDependency(
+	t *testing.T,
+	N1Resolution dgraph.ResolutionStatus,
+	expectedN2Resolution dgraph.ResolutionStatus,
+	closure func(n1 dgraph.Node[string], n2 dgraph.Node[string]),
+) {
 	d := dgraph.New[string]()
 	n1, err := d.AddNode("node-1", "test1")
 	assert.NoError(t, err)
@@ -145,38 +152,34 @@ func TestDirectedGraph_OneAndDependencyConnect(t *testing.T) {
 	n2, err := d.AddNode("node-2", "test2")
 	assert.NoError(t, err)
 
-	// Use simple connect method, which will set an AND dependency.
-	assert.NoError(t, n1.Connect(n2.ID()))
+	closure(n1, n2)
 
 	assert.NoError(t, d.PushStartingNodes())
 	readyNodes := d.PopReadyNodes()
 	assert.Equals(t, len(readyNodes), 1)
 	assert.Equals(t, readyNodes[0].ID(), n1.ID())
-	assert.NoError(t, n1.ResolveNode(dgraph.Resolved))
+	assert.NoError(t, n1.ResolveNode(N1Resolution))
+	assert.Equals(t, n1.ResolutionStatus(), N1Resolution)
 	readyNodes = d.PopReadyNodes()
 	assert.Equals(t, len(readyNodes), 1)
 	assert.Equals(t, readyNodes[0].ID(), n2.ID())
+	assert.Equals(t, n2.ResolutionStatus(), expectedN2Resolution)
+}
+
+func TestDirectedGraph_OneAndDependencyConnect(t *testing.T) {
+	testSingleResolutionDependency(t, dgraph.Resolved, dgraph.Waiting,
+		func(n1 dgraph.Node[string], n2 dgraph.Node[string]) {
+			// Use simple connect method, which will set an AND dependency.
+			assert.NoError(t, n1.Connect(n2.ID()))
+		})
 }
 
 func TestDirectedGraph_OneAndDependencyConnectDependency(t *testing.T) {
-	d := dgraph.New[string]()
-	n1, err := d.AddNode("node-1", "test1")
-	assert.NoError(t, err)
-
-	n2, err := d.AddNode("node-2", "test2")
-	assert.NoError(t, err)
-
-	// Use the dependency connection method instead.
-	assert.NoError(t, n2.ConnectDependency(n1.ID(), dgraph.AndDependency))
-
-	assert.NoError(t, d.PushStartingNodes())
-	readyNodes := d.PopReadyNodes()
-	assert.Equals(t, len(readyNodes), 1)
-	assert.Equals(t, readyNodes[0].ID(), n1.ID())
-	assert.NoError(t, n1.ResolveNode(dgraph.Resolved))
-	readyNodes = d.PopReadyNodes()
-	assert.Equals(t, len(readyNodes), 1)
-	assert.Equals(t, readyNodes[0].ID(), n2.ID())
+	testSingleResolutionDependency(t, dgraph.Resolved, dgraph.Waiting,
+		func(n1 dgraph.Node[string], n2 dgraph.Node[string]) {
+			// Use the dependency connection method instead.
+			assert.NoError(t, n2.ConnectDependency(n1.ID(), dgraph.AndDependency))
+		})
 }
 
 // Test two AND dependencies.
@@ -211,24 +214,11 @@ func TestDirectedGraph_TwoAndDependencies(t *testing.T) {
 
 // Test one OR dependency.
 func TestDirectedGraph_OneOrDependency(t *testing.T) {
-	d := dgraph.New[string]()
-	n1, err := d.AddNode("node-1", "test1")
-	assert.NoError(t, err)
-
-	n2, err := d.AddNode("node-2", "test2")
-	assert.NoError(t, err)
-
-	// Use the dependency connection method instead.
-	assert.NoError(t, n2.ConnectDependency(n1.ID(), dgraph.OrDependency))
-
-	assert.NoError(t, d.PushStartingNodes())
-	readyNodes := d.PopReadyNodes()
-	assert.Equals(t, len(readyNodes), 1)
-	assert.Equals(t, readyNodes[0].ID(), n1.ID())
-	assert.NoError(t, n1.ResolveNode(dgraph.Resolved))
-	readyNodes = d.PopReadyNodes()
-	assert.Equals(t, len(readyNodes), 1)
-	assert.Equals(t, readyNodes[0].ID(), n2.ID())
+	testSingleResolutionDependency(t, dgraph.Resolved, dgraph.Waiting,
+		func(n1 dgraph.Node[string], n2 dgraph.Node[string]) {
+			assert.NoError(t, n2.ConnectDependency(n1.ID(), dgraph.OrDependency))
+		},
+	)
 }
 
 // Test two OR dependencies.
@@ -393,11 +383,262 @@ func TestDirectedGraph_OneAndAndTwoOrDependencies(t *testing.T) {
 	assert.Equals(t, readyNodes[0].ID(), n1.ID())
 }
 
-// TODO: Test unresolvable with a simple AND
-// TODO: Test unresolvable with a simple OR.
-// TODO: Test unresolvable with two AND with one failure.
-// TODO: Test unresolvable with two OR with one failure and one success.
-// TODO: Test unresolvable with a simple completion dependency.
-// TODO: Test unresolvable with a completion dependency and an AND.
-// TODO: Test unresolvable with a completion dependency and two OR, with the completion dependency unresolvable.
-// TODO: Test unresolvable with two ORs and two AND.
+// Test unresolvable with a simple AND
+func TestDirectedGraph_OneUnresolvableAndDependency(t *testing.T) {
+	testSingleResolutionDependency(t, dgraph.Unresolvable, dgraph.Unresolvable,
+		func(n1 dgraph.Node[string], n2 dgraph.Node[string]) {
+			assert.NoError(t, n2.ConnectDependency(n1.ID(), dgraph.AndDependency))
+		},
+	)
+}
+
+// Test unresolvable with a simple OR.
+func TestDirectedGraph_OneUnresolvableOrDependency(t *testing.T) {
+	testSingleResolutionDependency(t, dgraph.Unresolvable, dgraph.Unresolvable,
+		func(n1 dgraph.Node[string], n2 dgraph.Node[string]) {
+			assert.NoError(t, n2.ConnectDependency(n1.ID(), dgraph.OrDependency))
+		},
+	)
+}
+
+// Test unresolvable with two AND with one failure.
+func TestDirectedGraph_TwoAndsOneFail(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+
+	// N2 && N3
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.AndDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.AndDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 2)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+
+	// Resolve one AND as unresolvable. That should exit early as unresolvable.
+	assert.NoError(t, n2.ResolveNode(dgraph.Unresolvable))
+
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+	assert.Equals(t, readyNodes[0].ResolutionStatus(), dgraph.Unresolvable)
+}
+
+// Test unresolvable with two OR with one failure and one success.
+func TestDirectedGraph_TwoOrsOneFail(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+
+	// N2 || N3
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.OrDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.OrDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 2)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+
+	// Resolve one OR as unresolvable. That alone is not enough to cause a problem.
+	assert.NoError(t, n2.ResolveNode(dgraph.Unresolvable))
+	assert.Equals(t, len(d.PopReadyNodes()), 0)
+
+	assert.NoError(t, n3.ResolveNode(dgraph.Resolved))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+	assert.Equals(t, readyNodes[0].ResolutionStatus(), dgraph.Waiting)
+}
+
+// Test unresolvable with a simple completion dependency.
+func TestDirectedGraph_OneUnresolvableCompletionDependency(t *testing.T) {
+	testSingleResolutionDependency(t, dgraph.Unresolvable, dgraph.Waiting,
+		func(n1 dgraph.Node[string], n2 dgraph.Node[string]) {
+			assert.NoError(t, n2.ConnectDependency(n1.ID(), dgraph.CompletionDependency))
+		},
+	)
+}
+
+// Test unresolvable with a completion dependency and an AND.
+func TestDirectedGraph_CompletionAndAnd(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.CompletionDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.AndDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 2)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+
+	// Resolve the completion dependency as unresolvable. That is equivalent to setting an AND dependency as resolved.
+	assert.NoError(t, n2.ResolveNode(dgraph.Unresolvable))
+	assert.Equals(t, len(d.PopReadyNodes()), 0)
+
+	assert.NoError(t, n3.ResolveNode(dgraph.Resolved))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+	assert.Equals(t, readyNodes[0].ResolutionStatus(), dgraph.Waiting)
+}
+
+// Test unresolvable with a completion dependency and two OR, with the completion dependency unresolvable.
+func TestDirectedGraph_CompletionAndTwoOrs(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+	n4, err := d.AddNode("node-4", "test4")
+	assert.NoError(t, err)
+
+	// N2 && (N3 || N4)
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.CompletionDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.OrDependency))
+	assert.NoError(t, n1.ConnectDependency(n4.ID(), dgraph.OrDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 3)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+	assert.SliceContains(t, n4, readyNodes)
+
+	// Resolve the completion dependency as unresolvable. That is equivalent to setting an AND dependency as resolved.
+	assert.NoError(t, n2.ResolveNode(dgraph.Unresolvable))
+	assert.Equals(t, len(d.PopReadyNodes()), 0)
+
+	assert.NoError(t, n3.ResolveNode(dgraph.Resolved))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+	assert.Equals(t, readyNodes[0].ResolutionStatus(), dgraph.Waiting)
+}
+
+// Test unresolvable with two ORs and two AND, with an AND being unresolvable.
+func TestDirectedGraph_UnresolvableAndsWithOrs(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+	n4, err := d.AddNode("node-4", "test4")
+	assert.NoError(t, err)
+	n5, err := d.AddNode("node-5", "test5")
+	assert.NoError(t, err)
+
+	// N2 && N3 && (N4 || N5)
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.AndDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.AndDependency))
+	assert.NoError(t, n1.ConnectDependency(n4.ID(), dgraph.OrDependency))
+	assert.NoError(t, n1.ConnectDependency(n5.ID(), dgraph.OrDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 4)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+	assert.SliceContains(t, n4, readyNodes)
+	assert.SliceContains(t, n5, readyNodes)
+
+	// Resolve an AND as unresolvable. This should cause instant failure.
+	assert.NoError(t, n2.ResolveNode(dgraph.Unresolvable))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+	assert.Equals(t, readyNodes[0].ResolutionStatus(), dgraph.Unresolvable)
+}
+
+// Test unresolvable with two ORs and two AND, with an OR being unresolvable.
+func TestDirectedGraph_UnresolvableOrsWithAnds(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	n3, err := d.AddNode("node-3", "test3")
+	assert.NoError(t, err)
+	n4, err := d.AddNode("node-4", "test4")
+	assert.NoError(t, err)
+	n5, err := d.AddNode("node-5", "test5")
+	assert.NoError(t, err)
+
+	// N2 && N3 && (N4 || N5)
+	assert.NoError(t, n1.ConnectDependency(n2.ID(), dgraph.AndDependency))
+	assert.NoError(t, n1.ConnectDependency(n3.ID(), dgraph.AndDependency))
+	assert.NoError(t, n1.ConnectDependency(n4.ID(), dgraph.OrDependency))
+	assert.NoError(t, n1.ConnectDependency(n5.ID(), dgraph.OrDependency))
+
+	assert.NoError(t, d.PushStartingNodes())
+	readyNodes := d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 4)
+	assert.SliceContains(t, n2, readyNodes)
+	assert.SliceContains(t, n3, readyNodes)
+	assert.SliceContains(t, n4, readyNodes)
+	assert.SliceContains(t, n5, readyNodes)
+
+	// Resolve an AND as unresolvable. This should cause instant failure.
+	assert.NoError(t, n4.ResolveNode(dgraph.Unresolvable))
+	assert.Equals(t, len(d.PopReadyNodes()), 0)
+
+	assert.NoError(t, n5.ResolveNode(dgraph.Unresolvable))
+	readyNodes = d.PopReadyNodes()
+	assert.Equals(t, len(readyNodes), 1)
+	assert.Equals(t, readyNodes[0].ID(), n1.ID())
+	assert.Equals(t, readyNodes[0].ResolutionStatus(), dgraph.Unresolvable)
+}
+
+func TestDirectedGraph_TestResolvingDeletedNode(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	assert.NoError(t, n1.Remove())
+	err = n1.ResolveNode(dgraph.Resolved)
+	assert.Error(t, err)
+	assert.InstanceOf[dgraph.ErrNodeDeleted](t, err)
+}
+
+func TestDirectedGraph_TestDoubleResolution(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	err = n1.ResolveNode(dgraph.Resolved)
+	assert.NoError(t, err)
+	err = n1.ResolveNode(dgraph.Resolved)
+	assert.Error(t, err)
+	assert.InstanceOf[dgraph.ErrNodeResolutionAlreadySet](t, err)
+}
+
+func TestDirectedGraph_TestWaitingResolution(t *testing.T) {
+	d := dgraph.New[string]()
+	n1, err := d.AddNode("node-1", "test1")
+	assert.NoError(t, err)
+	n2, err := d.AddNode("node-2", "test2")
+	assert.NoError(t, err)
+	assert.NoError(t, n2.ConnectDependency(n1.ID(), dgraph.AndDependency))
+	// Add a connection to ensure no negative effects due to propagation.
+	err = n1.ResolveNode(dgraph.Waiting)
+	assert.NoError(t, err)
+}

--- a/errors.go
+++ b/errors.go
@@ -4,78 +4,116 @@ import "fmt"
 
 // ErrNodeDeleted indicates that the current node has already been removed from the DirectedGraph.
 type ErrNodeDeleted struct {
-    NodeID string
+	NodeID string
 }
 
 func (e ErrNodeDeleted) Error() string {
-    return fmt.Sprintf("node with ID %s is deleted", e.NodeID)
+	return fmt.Sprintf("node with ID %s is deleted", e.NodeID)
 }
 
 // ErrCannotConnectToSelf indicates that an attempt was made to connect a node to itself.
 type ErrCannotConnectToSelf struct {
-    NodeID string
+	NodeID string
 }
 
 func (e ErrCannotConnectToSelf) Error() string {
-    return fmt.Sprintf("cannot connect node %s to itself", e.NodeID)
+	return fmt.Sprintf("cannot connect node %s to itself", e.NodeID)
 }
 
 // ErrNodeNotFound is an error that is returned if the specified node is not found.
 type ErrNodeNotFound struct {
-    NodeID string
+	NodeID string
 }
 
 func (e ErrNodeNotFound) Error() string {
-    return fmt.Sprintf("node with ID %s not found", e.NodeID)
+	return fmt.Sprintf("node with ID %s not found", e.NodeID)
 }
 
 // ErrNodeAlreadyExists signals that a node with the specified ID already exists.
 type ErrNodeAlreadyExists struct {
-    NodeID string
+	NodeID string
 }
 
 func (e ErrNodeAlreadyExists) Error() string {
-    return fmt.Sprintf("node with ID %s already exists", e.NodeID)
+	return fmt.Sprintf("node with ID %s already exists", e.NodeID)
 }
 
 // ErrConnectionWouldCreateACycle is an error that is returned if the newly created connection would create a cycle.
 type ErrConnectionWouldCreateACycle struct {
-    SourceNodeID      string
-    DestinationNodeID string
+	SourceNodeID      string
+	DestinationNodeID string
 }
 
 func (e ErrConnectionWouldCreateACycle) Error() string {
-    return fmt.Sprintf(
-        "connection from node %s to node %s would create a cycle",
-        e.SourceNodeID,
-        e.DestinationNodeID,
-    )
+	return fmt.Sprintf(
+		"connection from node %s to node %s would create a cycle",
+		e.SourceNodeID,
+		e.DestinationNodeID,
+	)
 }
 
 // ErrConnectionAlreadyExists indicates that the connection you are trying to create already exists.
 type ErrConnectionAlreadyExists struct {
-    SourceNodeID      string
-    DestinationNodeID string
+	SourceNodeID      string
+	DestinationNodeID string
 }
 
 func (e ErrConnectionAlreadyExists) Error() string {
-    return fmt.Sprintf(
-        "connection from node %s to node %s already exists",
-        e.SourceNodeID,
-        e.DestinationNodeID,
-    )
+	return fmt.Sprintf(
+		"connection from node %s to node %s already exists",
+		e.SourceNodeID,
+		e.DestinationNodeID,
+	)
 }
 
 // ErrConnectionDoesNotExist is returned if the specified connection between the two nodes does not exist.
 type ErrConnectionDoesNotExist struct {
-    SourceNodeID      string
-    DestinationNodeID string
+	SourceNodeID      string
+	DestinationNodeID string
 }
 
 func (e ErrConnectionDoesNotExist) Error() string {
-    return fmt.Sprintf(
-        "connection from node %s to node %s does not exist",
-        e.SourceNodeID,
-        e.DestinationNodeID,
-    )
+	return fmt.Sprintf(
+		"connection from node %s to node %s does not exist",
+		e.SourceNodeID,
+		e.DestinationNodeID,
+	)
+}
+
+type ErrNodeResolutionAlreadySet struct {
+	NodeID         string
+	ExistingStatus ResolutionStatus
+	NewStatus      ResolutionStatus
+}
+
+func (e ErrNodeResolutionAlreadySet) Error() string {
+	return fmt.Sprintf(
+		"attempted to re-resolve node %s with resolution %s; already set to %s",
+		e.NodeID, e.NewStatus, e.ExistingStatus,
+	)
+}
+
+type ErrDuplicateDependencyResolution struct {
+	NodeID       string
+	DependencyID string
+}
+
+func (e ErrDuplicateDependencyResolution) Error() string {
+	return fmt.Sprintf(
+		"attempted to re-resolve dependency %s of node %s; the connection remains; but there are"+
+			" no outstanding requirements",
+		e.NodeID, e.DependencyID,
+	)
+}
+
+type ErrNotifiedOfWaiting struct {
+	NodeID       string
+	DependencyID string
+}
+
+func (e ErrNotifiedOfWaiting) Error() string {
+	return fmt.Sprintf(
+		"notified node %s of waiting resolution of dependency %s; expected a non-waiting state",
+		e.NodeID, e.DependencyID,
+	)
 }

--- a/errors.go
+++ b/errors.go
@@ -8,7 +8,7 @@ type ErrNodeDeleted struct {
 }
 
 func (e ErrNodeDeleted) Error() string {
-	return fmt.Sprintf("node with ID %s is deleted", e.NodeID)
+	return fmt.Sprintf("node with ID %q is deleted", e.NodeID)
 }
 
 // ErrCannotConnectToSelf indicates that an attempt was made to connect a node to itself.
@@ -17,7 +17,7 @@ type ErrCannotConnectToSelf struct {
 }
 
 func (e ErrCannotConnectToSelf) Error() string {
-	return fmt.Sprintf("cannot connect node %s to itself", e.NodeID)
+	return fmt.Sprintf("cannot connect node %q to itself", e.NodeID)
 }
 
 // ErrNodeNotFound is an error that is returned if the specified node is not found.
@@ -26,7 +26,7 @@ type ErrNodeNotFound struct {
 }
 
 func (e ErrNodeNotFound) Error() string {
-	return fmt.Sprintf("node with ID %s not found", e.NodeID)
+	return fmt.Sprintf("node with ID %q not found", e.NodeID)
 }
 
 // ErrNodeAlreadyExists signals that a node with the specified ID already exists.
@@ -35,7 +35,7 @@ type ErrNodeAlreadyExists struct {
 }
 
 func (e ErrNodeAlreadyExists) Error() string {
-	return fmt.Sprintf("node with ID %s already exists", e.NodeID)
+	return fmt.Sprintf("node with ID %q already exists", e.NodeID)
 }
 
 // ErrConnectionWouldCreateACycle is an error that is returned if the newly created connection would create a cycle.
@@ -46,7 +46,7 @@ type ErrConnectionWouldCreateACycle struct {
 
 func (e ErrConnectionWouldCreateACycle) Error() string {
 	return fmt.Sprintf(
-		"connection from node %s to node %s would create a cycle",
+		"connection from node %q to node %q would create a cycle",
 		e.SourceNodeID,
 		e.DestinationNodeID,
 	)
@@ -60,7 +60,7 @@ type ErrConnectionAlreadyExists struct {
 
 func (e ErrConnectionAlreadyExists) Error() string {
 	return fmt.Sprintf(
-		"connection from node %s to node %s already exists",
+		"connection from node %q to node %q already exists",
 		e.SourceNodeID,
 		e.DestinationNodeID,
 	)
@@ -74,7 +74,7 @@ type ErrConnectionDoesNotExist struct {
 
 func (e ErrConnectionDoesNotExist) Error() string {
 	return fmt.Sprintf(
-		"connection from node %s to node %s does not exist",
+		"connection from node %q to node %q does not exist",
 		e.SourceNodeID,
 		e.DestinationNodeID,
 	)
@@ -88,8 +88,19 @@ type ErrNodeResolutionAlreadySet struct {
 
 func (e ErrNodeResolutionAlreadySet) Error() string {
 	return fmt.Sprintf(
-		"attempted to re-resolve node %s with resolution %s; already set to %s",
+		"attempted to re-resolve node %q with resolution %q; already set to %q",
 		e.NodeID, e.NewStatus, e.ExistingStatus,
+	)
+}
+
+type ErrNodeResolutionUnknown struct {
+	NodeID         string
+	ExistingStatus ResolutionStatus
+}
+
+func (e ErrNodeResolutionUnknown) Error() string {
+	return fmt.Sprintf("while resolving node %q; the existing resolution field had an invalid value of %q",
+		e.NodeID, e.ExistingStatus,
 	)
 }
 
@@ -100,7 +111,7 @@ type ErrDuplicateDependencyResolution struct {
 
 func (e ErrDuplicateDependencyResolution) Error() string {
 	return fmt.Sprintf(
-		"attempted to re-resolve dependency %s of node %s; the connection remains; but there are"+
+		"attempted to re-resolve dependency %q of node %q; the connection remains; but there are"+
 			" no outstanding requirements",
 		e.NodeID, e.DependencyID,
 	)
@@ -113,7 +124,7 @@ type ErrNotifiedOfWaiting struct {
 
 func (e ErrNotifiedOfWaiting) Error() string {
 	return fmt.Sprintf(
-		"notified node %s of waiting resolution of dependency %s; expected a non-waiting state",
+		"notified node %q of waiting resolution of dependency %q; expected a non-waiting state",
 		e.NodeID, e.DependencyID,
 	)
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -4,14 +4,18 @@ type DependencyType string
 
 const (
 	// OrDependency means the dependencies are resolved when all `AND`s and a single `OR` dependency is resolved.
+	// In other words, one OR short-circuits all ORs, but not ANDs.
 	OrDependency DependencyType = "or"
 	// AndDependency means the dependency is required no matter what.
 	AndDependency DependencyType = "and"
 	// CompletionDependency means the dependency will resolve due to either resolution or failure.
 	CompletionDependency DependencyType = "completion"
+	// PostResolutionDependency is for dependencies that no longer have an effect due to a prior resolution.
+	// For example, if one OR is resolved, all other OR dependencies are changed to PostResolutionDependency.
+	PostResolutionDependency DependencyType = "soft-post-resolution"
 	// SoftDependency means the dependency does not wait for this dependency to resolve.
 	// The dependency may be unresolved at the time of resolution.
-	SoftDependency DependencyType = "soft"
+	//SoftDependency DependencyType = "soft"
 )
 
 // ResolutionStatus indicates the status of the node for situations
@@ -42,8 +46,12 @@ type DirectedGraph[NodeType any] interface {
 	Clone() DirectedGraph[NodeType]
 	// HasCycles performs cycle detection and returns true if the DirectedGraph has cycles.
 	HasCycles() bool
-	// ListFinalizedNodes lists all nodes that have finalized their status, whether resolved or unresolvable.
-	//ListFinalizedNodes()
+	// PopReadyNodes lists all nodes that have finalized their status, whether resolved
+	// or unresolvable, and clears the list.
+	PopReadyNodes() []*node[NodeType]
+	// PushStartingNodes pushes the initial nodes without dependencies for access with PopReadyNodes()
+	// O(N), so use only at the start.
+	PushStartingNodes() error
 
 	// Mermaid outputs the graph as a Mermaid string.
 	Mermaid() string

--- a/interfaces.go
+++ b/interfaces.go
@@ -10,9 +10,9 @@ const (
 	AndDependency DependencyType = "and"
 	// CompletionDependency means the dependency will resolve due to either resolution or failure.
 	CompletionDependency DependencyType = "completion"
-	// PostResolutionDependency is for dependencies that no longer have an effect due to a prior resolution.
-	// For example, if one OR is resolved, all other OR dependencies are changed to PostResolutionDependency.
-	PostResolutionDependency DependencyType = "soft-post-resolution"
+	// ObviatedDependency is for dependencies that no longer have an effect due to a prior resolution.
+	// For example, if one OR is resolved, all other OR dependencies are changed to ObviatedDependency.
+	ObviatedDependency DependencyType = "obviated-dependency"
 	// SoftDependency means the dependency does not wait for this dependency to resolve.
 	// The dependency may be unresolved at the time of resolution.
 	//SoftDependency DependencyType = "soft"
@@ -88,7 +88,4 @@ type Node[NodeType any] interface {
 	// updates the nodes that follow it in the graph.
 	// The resolution must happen only one time, or else a ErrNodeResolutionAlreadySet is returned.
 	ResolveNode(status ResolutionStatus) error
-	// DependencyResolved is used to notify a node that one of its dependencies have had their resolution
-	// status set. Once all dependencies are resolved, the node is set as finalized (ready for processing).
-	DependencyResolved(dependencyNodeID string, dependencyResolution ResolutionStatus) error
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,46 +1,86 @@
 package dgraph
 
+type DependencyType string
+
+const (
+	// OrDependency means the dependencies are resolved when all `AND`s and a single `OR` dependency is resolved.
+	OrDependency DependencyType = "or"
+	// AndDependency means the dependency is required no matter what.
+	AndDependency DependencyType = "and"
+	// CompletionDependency means the dependency will resolve due to either resolution or failure.
+	CompletionDependency DependencyType = "completion"
+	// SoftDependency means the dependency does not wait for this dependency to resolve.
+	// The dependency may be unresolved at the time of resolution.
+	SoftDependency DependencyType = "soft"
+)
+
+// ResolutionStatus indicates the status of the node for situations
+//
+// The way the resolution system works is first the DAG is created, with
+// all nodes created, and all of their dependencies set.
+type ResolutionStatus string
+
+const (
+	WaitingForDependencies ResolutionStatus = "waiting"
+	Resolved               ResolutionStatus = "resolved"
+	Unresolvable           ResolutionStatus = "unresolvable"
+)
+
 // DirectedGraph is the representation of a Directed Graph width nodes and directed connections.
 type DirectedGraph[NodeType any] interface {
-    // AddNode adds a node with the specified ID. If the node already exists, it returns an ErrNodeAlreadyExists.
-    AddNode(id string, item NodeType) (Node[NodeType], error)
-    // GetNodeByID returns a node with the specified ID. If the specified node does not exist, an ErrNodeNotFound is
-    // returned.
-    GetNodeByID(id string) (Node[NodeType], error)
-    // ListNodes lists all nodes in the graph.
-    ListNodes() map[string]Node[NodeType]
-    // ListNodesWithoutInboundConnections lists all nodes that do not have an inbound connection. This is useful for
-    // performing a topological sort.
-    ListNodesWithoutInboundConnections() map[string]Node[NodeType]
-    // Clone creates an independent copy of the current directed graph.
-    Clone() DirectedGraph[NodeType]
-    // HasCycles performs cycle detection and returns true if the DirectedGraph has cycles.
-    HasCycles() bool
+	// AddNode adds a node with the specified ID. If the node already exists, it returns an ErrNodeAlreadyExists.
+	AddNode(id string, item NodeType) (Node[NodeType], error)
+	// GetNodeByID returns a node with the specified ID. If the specified node does not exist, an ErrNodeNotFound is
+	// returned.
+	GetNodeByID(id string) (Node[NodeType], error)
+	// ListNodes lists all nodes in the graph.
+	ListNodes() map[string]Node[NodeType]
+	// ListNodesWithoutInboundConnections lists all nodes that do not have an inbound connection. This is useful for
+	// performing a topological sort.
+	ListNodesWithoutInboundConnections() map[string]Node[NodeType]
+	// Clone creates an independent copy of the current directed graph.
+	Clone() DirectedGraph[NodeType]
+	// HasCycles performs cycle detection and returns true if the DirectedGraph has cycles.
+	HasCycles() bool
+	// ListFinalizedNodes lists all nodes that have finalized their status, whether resolved or unresolvable.
+	//ListFinalizedNodes()
 
-    // Mermaid outputs the graph as a Mermaid string.
-    Mermaid() string
+	// Mermaid outputs the graph as a Mermaid string.
+	Mermaid() string
 }
 
 // Node is a single point in a DirectedGraph.
 type Node[NodeType any] interface {
-    // ID returns the unique identifier of the node in the DG.
-    ID() string
-    // Item returns the underlying item for the node.
-    Item() NodeType
-    // Connect creates a new connection from the current node to the specified node. If the specified node does not
-    // exist, ErrNodeNotFound is returned. If the connection had created a cycle, ErrConnectionWouldCreateACycle
-    // is returned.
-    Connect(toNodeID string) error
-    // DisconnectInbound removes an incoming connection from the specified node. If the connection does not exist, an
-    // ErrConnectionDoesNotExist is returned.
-    DisconnectInbound(fromNodeID string) error
-    // DisconnectOutbound removes an outgoing connection to the specified node. If the connection does not exist, an
-    // ErrConnectionDoesNotExist is returned.
-    DisconnectOutbound(toNodeID string) error
-    // Remove removes the current node and all connections from the DirectedGraph.
-    Remove() error
-    // ListInboundConnections lists all inbound connections to this node.
-    ListInboundConnections() (map[string]Node[NodeType], error)
-    // ListOutboundConnections lists all outbound connections from this node.
-    ListOutboundConnections() (map[string]Node[NodeType], error)
+	// ID returns the unique identifier of the node in the DG.
+	ID() string
+	// Item returns the underlying item for the node.
+	Item() NodeType
+	// Connect creates a new connection from the current node to the specified node. If the specified node does not
+	// exist, ErrNodeNotFound is returned. If the connection had created a cycle, ErrConnectionWouldCreateACycle
+	// is returned. Sets the dependency type to an AND dependency.
+	Connect(toNodeID string) error
+	// ConnectDependency creates a new connection from the specified node to the current node.
+	// The dependency type is set to determine when the node becomes finalized.
+	// If the specified node does not exist, ErrNodeNotFound is returned. If the connection had
+	// created a cycle, ErrConnectionWouldCreateACycle is returned.
+	ConnectDependency(fromNodeID string, dependencyType DependencyType) error
+	// DisconnectInbound removes an incoming connection from the specified node. If the connection does not exist, an
+	// ErrConnectionDoesNotExist is returned.
+	DisconnectInbound(fromNodeID string) error
+	// DisconnectOutbound removes an outgoing connection to the specified node. If the connection does not exist, an
+	// ErrConnectionDoesNotExist is returned.
+	DisconnectOutbound(toNodeID string) error
+	// Remove removes the current node and all connections from the DirectedGraph.
+	Remove() error
+	// ListInboundConnections lists all inbound connections to this node.
+	ListInboundConnections() (map[string]Node[NodeType], error)
+	// ListOutboundConnections lists all outbound connections from this node.
+	ListOutboundConnections() (map[string]Node[NodeType], error)
+	// ResolveNode sets the resolution status of the node, and
+	// updates the nodes that follow it in the graph.
+	// The resolution must happen only one time, or else a ErrNodeResolutionAlreadySet is returned.
+	ResolveNode(status ResolutionStatus) error
+	// DependencyResolved is used to notify a node that one of its dependencies have had their resolution
+	// status set. Once all dependencies are resolved, the node is set as finalized (ready for processing).
+	DependencyResolved(dependencyNodeID string, dependencyResolution ResolutionStatus) error
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -8,11 +8,11 @@ const (
 	OrDependency DependencyType = "or"
 	// AndDependency means the dependency is required for resolution.
 	AndDependency DependencyType = "and"
-	// CompletionDependency means the dependency will resolve due to either resolution or failure.
-	CompletionDependency DependencyType = "completion"
+	// CompletionAndDependency means the dependency will resolve due to either resolution or failure.
+	CompletionAndDependency DependencyType = "completion-and"
 	// ObviatedDependency is for dependencies that no longer have an effect due to a prior resolution.
 	// For example, if one OR is resolved, all other OR dependencies are changed to ObviatedDependency.
-	ObviatedDependency DependencyType = "obviated-dependency"
+	ObviatedDependency DependencyType = "obviated"
 )
 
 // ResolutionStatus indicates the individual status of the node.
@@ -85,12 +85,16 @@ type Node[NodeType any] interface {
 	ListOutboundConnections() (map[string]Node[NodeType], error)
 	// ResolveNode sets the resolution status of the node, and updates the nodes that follow it in the graph.
 	// The resolution must happen only one time, or else a ErrNodeResolutionAlreadySet is returned.
+	// This transitions the resolution status from the existing state (typically Waiting) to the given state.
 	ResolveNode(status ResolutionStatus) error
 	// ResolutionStatus returns the resolution status. See the ResolutionStatus type.
 	// This is separate from the ready status (see IsReady).
 	// If a required dependency is marked unresolvable, the node's status will be set to Unresolvable.
 	ResolutionStatus() ResolutionStatus
 	// IsReady returns whether the node's dependencies have been resolved, making this node ready for processing.
+	// Recommended for debugging and testing.
+	// If marked not ready, the value may change at any time. For a reliable method of getting the node when it
+	// is ready, call `PopReadyNodes()`. Once a node is marked ready, it is final and cannot be marked not ready.
 	IsReady() bool
 	// OutstandingDependencies returns a map of the dependency node ID to the DependencyType of the dependency.
 	OutstandingDependencies() map[string]DependencyType

--- a/interfaces.go
+++ b/interfaces.go
@@ -25,9 +25,9 @@ const (
 type ResolutionStatus string
 
 const (
-	WaitingForDependencies ResolutionStatus = "waiting"
-	Resolved               ResolutionStatus = "resolved"
-	Unresolvable           ResolutionStatus = "unresolvable"
+	Waiting      ResolutionStatus = "waiting"
+	Resolved     ResolutionStatus = "resolved"
+	Unresolvable ResolutionStatus = "unresolvable"
 )
 
 // DirectedGraph is the representation of a Directed Graph width nodes and directed connections.
@@ -84,8 +84,13 @@ type Node[NodeType any] interface {
 	ListInboundConnections() (map[string]Node[NodeType], error)
 	// ListOutboundConnections lists all outbound connections from this node.
 	ListOutboundConnections() (map[string]Node[NodeType], error)
-	// ResolveNode sets the resolution status of the node, and
-	// updates the nodes that follow it in the graph.
+	// ResolveNode sets the resolution status of the node, and updates the nodes that follow it in the graph.
 	// The resolution must happen only one time, or else a ErrNodeResolutionAlreadySet is returned.
 	ResolveNode(status ResolutionStatus) error
+	// ResolutionStatus returns the resolution status. See the ResolutionStatus type.
+	// This is separate from the ready status (see IsReady).
+	// If a required dependency is marked unresolvable, the node's status will be set to Unresolvable.
+	ResolutionStatus() ResolutionStatus
+	// IsReady returns whether the node's dependencies have been resolved, making this node ready for processing.
+	IsReady() bool
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -93,4 +93,6 @@ type Node[NodeType any] interface {
 	ResolutionStatus() ResolutionStatus
 	// IsReady returns whether the node's dependencies have been resolved, making this node ready for processing.
 	IsReady() bool
+	// OutstandingDependencies returns a map of the dependency node ID to the DependencyType of the dependency.
+	OutstandingDependencies() map[string]DependencyType
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -89,9 +89,8 @@ type Node[NodeType any] interface {
 	// The resolution must happen only one time, or else a ErrNodeResolutionAlreadySet is returned.
 	// This transitions the resolution status from the existing state (typically Waiting) to the given state.
 	ResolveNode(status ResolutionStatus) error
-	// ResolutionStatus returns the resolution status. See the ResolutionStatus type.
-	// This is separate from the ready status (see IsReady).
-	// If a required dependency is marked unresolvable, the node's status will be set to Unresolvable.
+	// ResolutionStatus returns the resolution status and the ready state. See the ResolutionStatus type.
+	// If a required dependency is marked `Unresolvable`, the node's status will be set to `Unresolvable`.
 	ResolutionStatus() ResolutionStatus
 	// IsReady returns whether the node's dependencies have been resolved, making this node ready for processing.
 	// Recommended for debugging and testing.

--- a/interfaces.go
+++ b/interfaces.go
@@ -89,7 +89,7 @@ type Node[NodeType any] interface {
 	// The resolution must happen only one time, or else a ErrNodeResolutionAlreadySet is returned.
 	// This transitions the resolution status from the existing state (typically Waiting) to the given state.
 	ResolveNode(status ResolutionStatus) error
-	// ResolutionStatus returns the resolution status and the ready state. See the ResolutionStatus type.
+	// ResolutionStatus returns the resolution status. See the ResolutionStatus type.
 	// If a required dependency is marked `Unresolvable`, the node's status will be set to `Unresolvable`.
 	ResolutionStatus() ResolutionStatus
 	// IsReady returns whether the node's dependencies have been resolved, making this node ready for processing.

--- a/interfaces.go
+++ b/interfaces.go
@@ -46,6 +46,8 @@ type DirectedGraph[NodeType any] interface {
 	HasCycles() bool
 	// PopReadyNodes returns of a list of all nodes that have finalized their status, whether
 	// resolved or unresolvable, and clears the list.
+	// A node becomes ready to process when all of its AND dependencies and at least one of
+	// its OR dependencies are resolved.
 	PopReadyNodes() []*node[NodeType]
 	// PushStartingNodes searches for the initial ready nodes without dependencies and saves them.
 	// The nodes can then be retrieved with a call to `PopReadyNodes()`.
@@ -93,6 +95,8 @@ type Node[NodeType any] interface {
 	ResolutionStatus() ResolutionStatus
 	// IsReady returns whether the node's dependencies have been resolved, making this node ready for processing.
 	// Recommended for debugging and testing.
+	// A node becomes ready to process when all of its AND dependencies and at least one of
+	// its OR dependencies are resolved.
 	// If marked not ready, the value may change at any time. For a reliable method of getting the node when it
 	// is ready, call `PopReadyNodes()`. Once a node is marked ready, it is final and cannot be marked not ready.
 	IsReady() bool

--- a/interfaces.go
+++ b/interfaces.go
@@ -48,7 +48,9 @@ type DirectedGraph[NodeType any] interface {
 	// resolved or unresolvable, and clears the list.
 	// A node becomes ready to process when all of its AND dependencies and at least one of
 	// its OR dependencies are resolved.
-	PopReadyNodes() []*node[NodeType]
+	PopReadyNodes() map[string]ResolutionStatus
+	// HasReadyNodes Checks to see if there are any ready nodes without clearing them.
+	HasReadyNodes() bool
 	// PushStartingNodes searches for the initial ready nodes without dependencies and saves them.
 	// The nodes can then be retrieved with a call to `PopReadyNodes()`.
 	// Recommended to be called only once following construction of the DAG.
@@ -89,16 +91,6 @@ type Node[NodeType any] interface {
 	// The resolution must happen only one time, or else a ErrNodeResolutionAlreadySet is returned.
 	// This transitions the resolution status from the existing state (typically Waiting) to the given state.
 	ResolveNode(status ResolutionStatus) error
-	// ResolutionStatus returns the resolution status. See the ResolutionStatus type.
-	// If a required dependency is marked `Unresolvable`, the node's status will be set to `Unresolvable`.
-	ResolutionStatus() ResolutionStatus
-	// IsReady returns whether the node's dependencies have been resolved, making this node ready for processing.
-	// Recommended for debugging and testing.
-	// A node becomes ready to process when all of its AND dependencies and at least one of
-	// its OR dependencies are resolved.
-	// If marked not ready, the value may change at any time. For a reliable method of getting the node when it
-	// is ready, call `PopReadyNodes()`. Once a node is marked ready, it is final and cannot be marked not ready.
-	IsReady() bool
 	// OutstandingDependencies returns a map of the dependency node ID to the DependencyType of the dependency.
 	OutstandingDependencies() map[string]DependencyType
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -49,7 +49,7 @@ type DirectedGraph[NodeType any] interface {
 	// A node becomes ready to process when all of its AND dependencies and at least one of
 	// its OR dependencies are resolved.
 	PopReadyNodes() map[string]ResolutionStatus
-	// HasReadyNodes Checks to see if there are any ready nodes without clearing them.
+	// HasReadyNodes checks to see if there are any ready nodes without clearing them.
 	HasReadyNodes() bool
 	// PushStartingNodes searches for the initial ready nodes without dependencies and saves them.
 	// The nodes can then be retrieved with a call to `PopReadyNodes()`.


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds a dependency system to the graph.
It is an alternative way to use the graph. It does not break the existing way of using it. This was tested.

Unfortunately I didn't catch the fact that the white-space format was completely overwritten. Disregard lines that only have white-space changes.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).