### PR TITLE
Allow double unresolve & Fix missed lock

### DIFF
--- a/dg.go
+++ b/dg.go
@@ -293,8 +293,10 @@ func (n *node[NodeType]) resolveNode(newStatus ResolutionStatus) error {
 		return ErrNodeDeleted{n.id}
 	}
 	if n.status != Waiting {
-		if n.status == Resolved || n.status == Unresolvable {
+		if n.status == Resolved {
 			return ErrNodeResolutionAlreadySet{n.id, n.status, newStatus}
+		} else if n.status == Unresolvable {
+			return nil // Allow nodes to be unresolved multiple times. But no processing is required.
 		} else {
 			return ErrNodeResolutionUnknown{n.id, n.status}
 		}

--- a/dg.go
+++ b/dg.go
@@ -296,7 +296,7 @@ func (n *node[NodeType]) resolveNode(newStatus ResolutionStatus) error {
 		return ErrNodeDeleted{n.id}
 	}
 	if n.status != Waiting {
-		if n.status == Resolved {
+		if n.status == Resolved || n.status == Unresolvable && newStatus != Unresolvable {
 			return ErrNodeResolutionAlreadySet{n.id, n.status, newStatus}
 		} else if n.status == Unresolvable {
 			return nil // Allow nodes to be unresolved multiple times. But no processing is required.

--- a/dg.go
+++ b/dg.go
@@ -32,6 +32,9 @@ type directedGraph[NodeType any] struct {
 var errorPathRegex, _ = regexp.Compile(`\.(?:error|crashed|failed|deploy_failed)$`)
 
 func (d *directedGraph[NodeType]) Mermaid() string {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
 	result := []string{
 		"%% Mermaid markdown workflow",
 		"flowchart LR",


### PR DESCRIPTION
## Changes introduced with this PR

The logic to now allow double resolutions makes sense, but since unresolutions can be propagated from two different nodes, that logic did not make sense, and caused problems.

In addition, while testing this change, I found a problem that resulted in concurrent access, so I locked it.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).