### PR TITLE
Lock to prevent rare race condition

### DIFF
--- a/dg.go
+++ b/dg.go
@@ -247,15 +247,14 @@ func (d *directedGraph[NodeType]) PopReadyNodes() map[string]ResolutionStatus {
 	result := make(map[string]ResolutionStatus)
 	d.lock.Lock()
 	defer d.lock.Unlock()
-	// Transfer the map to a local variable to minimize time locked, and reset the graph's value.
-	readyMap := d.readyForProcessing
-	d.readyForProcessing = make(map[string]*node[NodeType])
-
-	for _, node := range readyMap {
-		// Technically, while unlikely, it's possible for the node's status to race with
-		// this access of node.status.
+	for _, node := range d.readyForProcessing {
+		// There are some conditions that may result in the status being modified,
+		// so this needs to be done under lock.
+		// For example, a ready waiting node being marked Resolved or Unresolvable by
+		// a user that retrieves the node by ID.
 		result[node.ID()] = node.status
 	}
+	clear(d.readyForProcessing)
 	return result
 }
 

--- a/dg.go
+++ b/dg.go
@@ -245,13 +245,13 @@ func (d *directedGraph[NodeType]) HasReadyNodes() bool {
 
 func (d *directedGraph[NodeType]) PopReadyNodes() map[string]ResolutionStatus {
 	result := make(map[string]ResolutionStatus)
+	// The statuses may be modified while or after this function is called,
+	// so this needs to be done under lock to satisfy the go race detector.
+	// For example, a ready waiting node being marked Resolved or Unresolvable by
+	// a user that retrieves the node by ID.
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	for _, node := range d.readyForProcessing {
-		// There are some conditions that may result in the status being modified,
-		// so this needs to be done under lock.
-		// For example, a ready waiting node being marked Resolved or Unresolvable by
-		// a user that retrieves the node by ID.
 		result[node.ID()] = node.status
 	}
 	clear(d.readyForProcessing)

--- a/dg.go
+++ b/dg.go
@@ -244,14 +244,16 @@ func (d *directedGraph[NodeType]) HasReadyNodes() bool {
 }
 
 func (d *directedGraph[NodeType]) PopReadyNodes() map[string]ResolutionStatus {
+	result := make(map[string]ResolutionStatus)
 	d.lock.Lock()
+	defer d.lock.Unlock()
 	// Transfer the map to a local variable to minimize time locked, and reset the graph's value.
 	readyMap := d.readyForProcessing
 	d.readyForProcessing = make(map[string]*node[NodeType])
-	d.lock.Unlock()
 
-	result := make(map[string]ResolutionStatus)
 	for _, node := range readyMap {
+		// Technically, while unlikely, it's possible for the node's status to race with
+		// this access of node.status.
 		result[node.ID()] = node.status
 	}
 	return result

--- a/interfaces.go
+++ b/interfaces.go
@@ -45,7 +45,7 @@ type DirectedGraph[NodeType any] interface {
 	// HasCycles performs cycle detection and returns true if the DirectedGraph has cycles.
 	HasCycles() bool
 	// PopReadyNodes returns of a list of all nodes that have finalized their status, whether
-	// resolved or unresolvable, and clears the list.
+	// resolved or unresolvable, and clears the list. Statuses may be stale after return.
 	// A node becomes ready to process when all of its AND dependencies and at least one of
 	// its OR dependencies are resolved.
 	PopReadyNodes() map[string]ResolutionStatus

--- a/interfaces.go
+++ b/interfaces.go
@@ -45,7 +45,7 @@ type DirectedGraph[NodeType any] interface {
 	// HasCycles performs cycle detection and returns true if the DirectedGraph has cycles.
 	HasCycles() bool
 	// PopReadyNodes returns of a list of all nodes that have no outstanding required dependencies,
-	// and are therefore ready, and clears the list.
+	// and are therefore ready, and clears the list. Statuses may be stale after return.
 	// A node becomes ready when all of its AND dependencies and at least one of
 	// its OR dependencies are resolved.
 	// Note that the resolution state of a node is independent of its readiness and that the


### PR DESCRIPTION
## Changes introduced with this PR

It's possible for a node to be accessed by a user's other thread while PopReadyNodes is processing the data. This code locks it to prevent it from happening at the same time.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).