### PR TITLE
Sort Mermaid output and add a test for it

### DIFF
--- a/dg.go
+++ b/dg.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -40,8 +41,7 @@ func (d *directedGraph[NodeType]) Mermaid() string {
 		"flowchart LR",
 		"%% Success path",
 	}
-
-	errorPath := []string{"%% Error path"}
+	var successPath, errorPath []string
 
 	for source, d := range d.connectionsFromNode {
 		for destination := range d {
@@ -50,13 +50,17 @@ func (d *directedGraph[NodeType]) Mermaid() string {
 			if isErrorPath {
 				errorPath = append(errorPath, connection)
 			} else {
-				result = append(result, connection)
+				successPath = append(successPath, connection)
 			}
 		}
 	}
 
-	result = append(result, errorPath...)
+	slices.Sort(successPath)
+	slices.Sort(errorPath)
 
+	result = append(result, successPath...)
+	result = append(result, "%% Error path")
+	result = append(result, errorPath...)
 	result = append(result, "%% Mermaid end")
 	return strings.Join(result, "\n") + "\n"
 }


### PR DESCRIPTION
## Changes introduced with this PR

This change modifies the Mermaid flow chart output to place the connections in sorted order.  This means that, if someone regenerates the chart and pastes the result into a `README.md` file, there should be no diffs unless the chart has actually changed.  (The current algorithm is apparently unstable, producing different orderings for the same dependencies at different times when it is run, which produces needless noise when the `README.md` file is updated.)

This change also introduces a test for `Mermaid()`.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).