### PR TITLE
Added optional dependencies

### DIFF
--- a/dg.go
+++ b/dg.go
@@ -486,8 +486,9 @@ func (n *node[NodeType]) dependencyResolved(dependencyNodeID string, dependencyR
 	return nil
 }
 
+// Marks a node as ready, and marks all outstanding optional dependencies as obviated.
+// Caller should have appropriate mutex locked before calling.
 func (n *node[NodeType]) markReady() {
-	// Once a node is ready, all outstanding optional dependencies are marked as obviated.
 	n.markObviated(OptionalDependency)
 	n.ready = true
 	n.dg.readyForProcessing[n.id] = n

--- a/interfaces.go
+++ b/interfaces.go
@@ -10,6 +10,9 @@ const (
 	AndDependency DependencyType = "and"
 	// CompletionAndDependency means the dependency will resolve due to either resolution or failure.
 	CompletionAndDependency DependencyType = "completion-and"
+	// OptionalDependency means the resolution of the dependency is tracked, but it has no effect
+	// on the ready or failure state of a node.
+	OptionalDependency DependencyType = "optional"
 	// ObviatedDependency is for dependencies that no longer have an effect due to a prior resolution.
 	// For example, if one OR is resolved, all other OR dependencies are changed to ObviatedDependency.
 	ObviatedDependency DependencyType = "obviated"


### PR DESCRIPTION
## Changes introduced with this PR

Now that I revised this repository to keep track of resolved dependencies, optional dependencies are more useful. I found a good way to use them in the engine.
Other than the dependency being tracked in the resolved and outstanding dependencies maps, it has no effect. It does not effect the ready state.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).