### PR TITLE
Update to Go 1.25

### DIFF
--- a/dg.go
+++ b/dg.go
@@ -478,7 +478,7 @@ func (n *node[NodeType]) dependencyResolved(dependencyNodeID string, dependencyR
 		}
 		hasAndDependency := n.hasOutstandingDependency(AndDependency) || n.hasOutstandingDependency(CompletionAndDependency)
 		// Now determine if it's ready to be finalized (no more deferred dependencies).
-		if !(hasAndDependency || hasOrDependency) {
+		if !hasAndDependency && !hasOrDependency {
 			// Mark as ready for processing internally and in the DAG.
 			n.markReady()
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module go.arcalot.io/dgraph
 
-go 1.22.0
+go 1.25
 
 require go.arcalot.io/assert v1.8.0


### PR DESCRIPTION
## Summary
- Update Go version from 1.22 to 1.25
- Update dependencies

Part of an org-wide effort to align with the one-release-behind policy (current stable: Go 1.26.x).